### PR TITLE
WASM override default sync contructors

### DIFF
--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -67,9 +67,10 @@ impl Deref for WasmIdentityClient {
 
 #[wasm_bindgen(js_class = IdentityClient)]
 impl WasmIdentityClient {
+  /// @deprecated Use `IdentityClient.create` instead.
   #[wasm_bindgen(constructor, skip_typescript)]
-  pub fn _new() -> JsError {
-    JsError::new("cannot build an instance of `IdentityClient` through its default sync constructor. Use `IdentityClient.create` instead.")
+  pub fn _new() -> Result<WasmIdentityClient> {
+    Err(JsError::new("cannot build an instance of `IdentityClient` through its default sync constructor. Use `IdentityClient.create` instead.").into())
   }
 
   #[wasm_bindgen(js_name = create)]

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -67,7 +67,7 @@ impl Deref for WasmIdentityClient {
 
 #[wasm_bindgen(js_class = IdentityClient)]
 impl WasmIdentityClient {
-  #[wasm_bindgen(constructor, skip_typescript)]  
+  #[wasm_bindgen(constructor, skip_typescript)]
   pub fn _new() -> JsError {
     JsError::new("cannot build an instance of `IdentityClient` through its default sync constructor. Use `IdentityClient.create` instead.")
   }

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -67,6 +67,11 @@ impl Deref for WasmIdentityClient {
 
 #[wasm_bindgen(js_class = IdentityClient)]
 impl WasmIdentityClient {
+  #[wasm_bindgen(constructor, skip_typescript)]  
+  pub fn _new() -> JsError {
+    JsError::new("cannot build an instance of `IdentityClient` through its default sync constructor. Use `IdentityClient.create` instead.")
+  }
+
   #[wasm_bindgen(js_name = create)]
   pub async fn new(client: WasmIdentityClientReadOnly, signer: WasmTransactionSigner) -> Result<WasmIdentityClient> {
     let inner_client = IdentityClient::new(client.0, signer).await.wasm_result()?;

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client.rs
@@ -68,7 +68,7 @@ impl Deref for WasmIdentityClient {
 #[wasm_bindgen(js_class = IdentityClient)]
 impl WasmIdentityClient {
   /// @deprecated Use `IdentityClient.create` instead.
-  #[wasm_bindgen(constructor, skip_typescript)]
+  #[wasm_bindgen(constructor)]
   pub fn _new() -> Result<WasmIdentityClient> {
     Err(JsError::new("cannot build an instance of `IdentityClient` through its default sync constructor. Use `IdentityClient.create` instead.").into())
   }

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -51,6 +51,11 @@ pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 // builder related functions
 #[wasm_bindgen(js_class = IdentityClientReadOnly)]
 impl WasmIdentityClientReadOnly {
+  #[wasm_bindgen(constructor, skip_typescript)]  
+  pub fn _new() -> JsError {
+    JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead.")
+  }
+
   #[wasm_bindgen(js_name = create)]
   pub async fn new(iota_client: WasmIotaClient) -> Result<WasmIdentityClientReadOnly, JsError> {
     let inner_client = IdentityClientReadOnly::new(iota_client).await?;

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -52,7 +52,7 @@ pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 #[wasm_bindgen(js_class = IdentityClientReadOnly)]
 impl WasmIdentityClientReadOnly {
   /// @deprecated Use `IdentityClientReadOnly.create` instead.
-  #[wasm_bindgen(constructor, skip_typescript)]
+  #[wasm_bindgen(constructor)]
   pub fn _new() -> Result<WasmIdentityClientReadOnly, JsError> {
     Err(JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead."))
   }

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -51,12 +51,10 @@ pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 // builder related functions
 #[wasm_bindgen(js_class = IdentityClientReadOnly)]
 impl WasmIdentityClientReadOnly {
-  #[wasm_bindgen(constructor, skip_typescript)]
   /// @deprecated Use `IdentityClientReadOnly.create` instead.
   #[wasm_bindgen(constructor, skip_typescript)]
   pub fn _new() -> Result<WasmIdentityClientReadOnly, JsError> {
     Err(JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead."))
-  }
   }
 
   #[wasm_bindgen(js_name = create)]

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -51,7 +51,7 @@ pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 // builder related functions
 #[wasm_bindgen(js_class = IdentityClientReadOnly)]
 impl WasmIdentityClientReadOnly {
-  #[wasm_bindgen(constructor, skip_typescript)]  
+  #[wasm_bindgen(constructor, skip_typescript)]
   pub fn _new() -> JsError {
     JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead.")
   }

--- a/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
+++ b/bindings/wasm/identity_wasm/src/rebased/wasm_identity_client_read_only.rs
@@ -52,8 +52,11 @@ pub struct WasmIdentityClientReadOnly(pub(crate) IdentityClientReadOnly);
 #[wasm_bindgen(js_class = IdentityClientReadOnly)]
 impl WasmIdentityClientReadOnly {
   #[wasm_bindgen(constructor, skip_typescript)]
-  pub fn _new() -> JsError {
-    JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead.")
+  /// @deprecated Use `IdentityClientReadOnly.create` instead.
+  #[wasm_bindgen(constructor, skip_typescript)]
+  pub fn _new() -> Result<WasmIdentityClientReadOnly, JsError> {
+    Err(JsError::new("cannot build an instance of `IdentityClientReadOnly` through its default sync constructor. Use `IdentityClientReadOnly.create` instead."))
+  }
   }
 
   #[wasm_bindgen(js_name = create)]


### PR DESCRIPTION
# Description of change
`IdentityClient` can only be built though an async operation but the default constructor - inherited by Object - allows to create an instance, although an invalid one. This behavior is deceptive and hence we override the constructor with one that always fails with an error that mentions the correct way to instantiate the client.

## Links to any relevant issues
Closes #1596 
