### PR TITLE
Fix clippy issues

### DIFF
--- a/examples/utils/utils.rs
+++ b/examples/utils/utils.rs
@@ -145,7 +145,7 @@ pub fn pretty_print_json(label: &str, value: &str) {
   let data: Value = serde_json::from_str(value).unwrap();
   let pretty_json = serde_json::to_string_pretty(&data).unwrap();
   println!("--------------------------------------");
-  println!("{}:", label);
+  println!("{label}:");
   println!("--------------------------------------");
-  println!("{} \n", pretty_json);
+  println!("{pretty_json} \n");
 }

--- a/identity_credential/src/revocation/revocation_bitmap_2022/document_ext.rs
+++ b/identity_credential/src/revocation/revocation_bitmap_2022/document_ext.rs
@@ -89,7 +89,7 @@ where
   let mut revocation_bitmap: RevocationBitmap = RevocationBitmap::try_from(&*service)?;
   f(&mut revocation_bitmap);
 
-  std::mem::swap(service.service_endpoint_mut(), &mut revocation_bitmap.to_endpoint()?);
+  *service.service_endpoint_mut() = revocation_bitmap.to_endpoint()?;
 
   Ok(())
 }

--- a/identity_credential/src/validator/jpt_credential_validation/jpt_credential_validator_utils.rs
+++ b/identity_credential/src/validator/jpt_credential_validation/jpt_credential_validator_utils.rs
@@ -170,8 +170,7 @@ impl JptCredentialValidatorUtils {
   ) -> ValidationUnitResult {
     let issuer_service_url: identity_did::DIDUrl = identity_did::DIDUrl::parse(status.id()).map_err(|err| {
       JwtValidationError::InvalidStatus(crate::Error::InvalidStatus(format!(
-        "could not convert status id to DIDUrl; {}",
-        err,
+        "could not convert status id to DIDUrl; {err}",
       )))
     })?;
 

--- a/identity_credential/src/validator/sd_jwt/validator.rs
+++ b/identity_credential/src/validator/sd_jwt/validator.rs
@@ -129,7 +129,7 @@ impl<V: JwsVerifier> SdJwtCredentialValidator<V> {
       identity_verification::jose::error::Error::InvalidClaim("sd-jwt claims could not be deserialized"),
     ))?;
     let decoded: String = Value::Object(self.1.decode(obj, disclosures).map_err(|e| {
-      let err_str = format!("sd-jwt claims decoding failed, {}", e);
+      let err_str = format!("sd-jwt claims decoding failed, {e}");
       let err: &'static str = Box::leak(err_str.into_boxed_str());
       JwtValidationError::JwsDecodingError(identity_verification::jose::error::Error::InvalidClaim(err))
     })?)

--- a/identity_iota_core/tests/e2e/common.rs
+++ b/identity_iota_core/tests/e2e/common.rs
@@ -157,7 +157,7 @@ async fn publish_package(active_address: IotaAddress) -> anyhow::Result<ObjectID
   let package_id_str = package_id.to_string();
   std::env::set_var("IDENTITY_IOTA_PKG_ID", package_id_str.as_str());
   let mut file = std::fs::File::create(CACHED_PKG_ID)?;
-  write!(&mut file, "{};{}", package_id_str, active_address)?;
+  write!(&mut file, "{active_address};{active_address}")?;
 
   Ok(package_id)
 }

--- a/identity_jose/src/jwk/conversion/ed25519.rs
+++ b/identity_jose/src/jwk/conversion/ed25519.rs
@@ -41,7 +41,7 @@ pub(crate) fn jwk_to_keypair(jwk: &Jwk) -> Result<Ed25519KeyPair, Error> {
     .as_deref()
     .map(jwu::decode_b64)
     .ok_or_else(|| Error::KeyConversion("expected Jwk `d` param to be present".to_string()))?
-    .map_err(|err| Error::KeyConversion(format!("unable to decode `d` param; {}", err)))?
+    .map_err(|err| Error::KeyConversion(format!("unable to decode `d` param; {err}")))?
     .try_into()
     .map_err(|_| Error::KeyConversion(format!("expected key of length {}", Ed25519PrivateKey::LENGTH)))?;
 


### PR DESCRIPTION
# Description of change
Fixes some clippy issues, that came up in the latest CI runs.

Mostly "variables can be used directly in the `format!` string" ([clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)) errors. And a single "swapping with a temporary value is inefficient" ([clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#swap_with_temporary)) error.

## Type of change
Add an `x` to the boxes that are relevant to your changes.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Chore

## How the change has been tested
Re-checked clippy locally, using CI to check test runs.

## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
