### PR TITLE
Implicit Move dependencies

### DIFF
--- a/identity_iota_core/packages/iota_identity/Move.toml
+++ b/identity_iota_core/packages/iota_identity/Move.toml
@@ -6,11 +6,6 @@ name = "IotaIdentity"
 edition = "2024"
 
 [dependencies]
-# 'tag' keyword not supported here, therefore use rev instead.
-# Current revision is v1.2.3.
-MoveStdlib = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/move-stdlib", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
-Stardust = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/stardust", rev = "d9dbd00f5601f20f9d0d8381fc674f70869c7910" }
 
 [addresses]
 iota_identity = "0x0"


### PR DESCRIPTION
Use the implicit dependencies instead of explicit for official IOTA packages