### PR TITLE
IOTA v1.5.0-rc - Test with product core feature branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ exclude = ["bindings/wasm/identity_wasm", "bindings/grpc"]
 
 [workspace.dependencies]
 bls12_381_plus = { version = "0.8.17" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
 strum = { version = "0.25", default-features = false, features = ["std", "derive"] }

--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -24,7 +24,7 @@ identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt"
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.1.2", features = ["stronghold"] }
 prost = "0.13"
 rand = "0.8.5"

--- a/bindings/grpc/Cargo.toml
+++ b/bindings/grpc/Cargo.toml
@@ -24,7 +24,7 @@ identity_iota = { path = "../../identity_iota", features = ["resolver", "sd-jwt"
 identity_jose = { path = "../../identity_jose" }
 identity_storage = { path = "../../identity_storage", features = ["memstore"] }
 identity_stronghold = { path = "../../identity_stronghold", features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.1.2", features = ["stronghold"] }
 prost = "0.13"
 rand = "0.8.5"

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -25,12 +25,12 @@ identity_ecdsa_verifier = { path = "../../../identity_ecdsa_verifier", default-f
 identity_eddsa_verifier = { path = "../../../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 # Remove iota-sdk dependency while working on issue #1445
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction_ts" }
 js-sys = { version = "0.3.61" }
 json-proof-token = "0.3.4"
 proc_typescript = { version = "0.1.0", path = "./proc_typescript" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction", "bindings", "gas-station", "default-http-client"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/bindings/wasm/identity_wasm/package-lock.json
+++ b/bindings/wasm/identity_wasm/package-lock.json
@@ -43,7 +43,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@iota/iota-sdk": "^1.2.0"
+        "@iota/iota-sdk": "^1.6.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@iota/bcs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.0.0.tgz",
-      "integrity": "sha512-oxXgpzlL0d2jbzZH/9XmLcM+jmPbYT1hbbPfkvzMZvGChIDw1zLvp1EFsJtb2hAcLHORIAHIV0xEhzhBpIlSqA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.2.0.tgz",
+      "integrity": "sha512-QdRSR0KpJ87tdjVNmM/j0+0DvE0aTxHIa02337iluaOsMqtJ8OdgUCfSyLduC/3qS+8tJE+UB1KOw55tF+sN2w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -263,20 +263,21 @@
       }
     },
     "node_modules/@iota/iota-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.2.0.tgz",
-      "integrity": "sha512-SzC3NFYuq2P3dNh79X679p9Frb1XylU8O3nfeOQL4NcEnf/44k5HY0ABeNuWHFoYoeuI0Uk+qSIEcIVSaaMoag==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.6.0.tgz",
+      "integrity": "sha512-SDO8SsleHfHyvN2iK3Mir/6dykCOt5HMwLdYBkBHAOvGbTVF/xqmEHhImK6o7uFhGGAHPD8cl7HCPQk/53i+NA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@iota/bcs": "1.0.0",
+        "@iota/bcs": "1.2.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
         "@suchipi/femver": "^1.0.0",
         "bech32": "^2.0.0",
+        "bignumber.js": "^9.1.1",
         "gql.tada": "^1.8.2",
         "graphql": "^16.9.0",
         "tweetnacl": "^1.0.3",
@@ -1311,6 +1312,16 @@
       "version": "5.2.2",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }

--- a/bindings/wasm/identity_wasm/package.json
+++ b/bindings/wasm/identity_wasm/package.json
@@ -83,7 +83,7 @@
     "node-fetch": "^2.6.7"
   },
   "peerDependencies": {
-    "@iota/iota-sdk": "^1.2.0"
+    "@iota/iota-sdk": "^1.6.0"
   },
   "engines": {
     "node": ">=20"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ identity_stronghold = { path = "../identity_stronghold", default-features = fals
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common", features = ["core-client", "transaction"] }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction"] }
 rand = "0.8.5"
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.62"
 identity_eddsa_verifier = { path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 identity_storage = { path = "../identity_storage" }
 identity_stronghold = { path = "../identity_stronghold", default-features = false, features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
 product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common", features = ["core-client", "transaction"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.62"
 identity_eddsa_verifier = { path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 identity_storage = { path = "../identity_storage" }
 identity_stronghold = { path = "../identity_stronghold", default-features = false, features = ["send-sync-storage"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 iota-sdk-legacy = { package = "iota-sdk", version = "1.0", default-features = false, features = ["tls", "client", "stronghold"] }
 json-proof-token.workspace = true
 product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common", features = ["core-client", "transaction"] }

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -30,7 +30,7 @@ iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag
 # required for doc test
 anyhow = "1.0.64"
 identity_iota = { version = "=1.6.0-beta", path = "./", features = ["memstore"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 rand = "0.8.5"
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
 tokio = { version = "1.46.1", features = ["full"] }

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -30,7 +30,7 @@ iota_interaction = { git = "https://github.com/iotaledger/product-core.git", bra
 # required for doc test
 anyhow = "1.0.64"
 identity_iota = { version = "=1.6.0-beta", path = "./", features = ["memstore"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0" }
 rand = "0.8.5"
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag = "v0.3.0" }
 tokio = { version = "1.46.1", features = ["full"] }

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -24,7 +24,7 @@ identity_verification = { version = "=1.6.0-beta", path = "../identity_verificat
 iota_interaction.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 # required for doc test

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -45,12 +45,12 @@ secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.5.0-rc", optional = true }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.5.0", optional = true }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", optional = true }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction_rust", optional = true }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc", optional = true }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0-rc", optional = true }
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0-rc", optional = true }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0", optional = true }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0", optional = true }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0", optional = true }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -45,12 +45,12 @@ secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", tag
 serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.4.1", optional = true }
+iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.5.0-rc", optional = true }
 iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", optional = true }
 iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_rust", optional = true }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1", optional = true }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.4.1", optional = true }
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.4.1", optional = true }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc", optional = true }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0-rc", optional = true }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0-rc", optional = true }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/identity_iota_core/Cargo.toml
+++ b/identity_iota_core/Cargo.toml
@@ -24,7 +24,7 @@ num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 prefix-hex = { version = "0.7", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common", default-features = false }
 ref-cast = { version = "1.0.14", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
@@ -46,15 +46,15 @@ serde-aux = { version = "4.5.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iota-config = { git = "https://github.com/iotaledger/iota.git", package = "iota-config", tag = "v1.5.0-rc", optional = true }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", optional = true }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction_rust", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", optional = true }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction_rust", optional = true }
 iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc", optional = true }
 move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0-rc", optional = true }
 shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0-rc", optional = true }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt", "process"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
 
 # Dependency iota_interaction_ts is always used on wasm32 platform. It is not controlled by the "iota-client" feature
 # because it's unclear how to implement this. wasm32 build will most probably always use the "iota-client" feature

--- a/identity_jose/Cargo.toml
+++ b/identity_jose/Cargo.toml
@@ -25,10 +25,10 @@ thiserror.workspace = true
 zeroize = { version = "1.6", default-features = false, features = ["std", "zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false }
 
 [dev-dependencies]
 iota-crypto = { version = "0.23", features = ["ed25519", "random", "hmac"] }

--- a/identity_storage/Cargo.toml
+++ b/identity_storage/Cargo.toml
@@ -37,17 +37,17 @@ tokio = { version = "1.46.1", default-features = false, features = ["macros", "s
 zkryptium = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "iota_interaction", default-features = false, optional = true }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "iota_interaction", default-features = false, optional = true }
 
 [dev-dependencies]
 identity_credential = { version = "=1.6.0-beta", path = "../identity_credential", features = ["revocation-bitmap"] }
 identity_ecdsa_verifier = { version = "=1.6.0-beta", path = "../identity_ecdsa_verifier", default-features = false, features = ["es256"] }
 identity_eddsa_verifier = { version = "=1.6.0-beta", path = "../identity_eddsa_verifier", default-features = false, features = ["ed25519"] }
 once_cell = { version = "1.18", default-features = false }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.0", package = "product_common", default-features = false }
+product_common = { git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-5-0-rc-upstream-merge", package = "product_common", default-features = false }
 tokio = { version = "1.46.1", default-features = false, features = ["macros", "sync", "rt"] }
 
 [features]


### PR DESCRIPTION
> [!WARNING]
> DON'T MERGE THIS PULL REQUEST
>
> This PR is only used to run CI tests against the `product-core` branch `feat/iota-v1-5-0-rc-upstream-merge`

Wasm CI tests will use the current [0.8.0 version of the @iota/iota-interaction-ts package](https://www.npmjs.com/package/@iota/iota-interaction-ts/v/0.8.0) and will probably be OK. A new release for the `@iota/iota-interaction-ts` npmjs package is not needed. Therefore these tests can be considered as a final evaluation.

The branch used for this PR is based on the IOTA v1-5-0-rc integration branch: https://github.com/iotaledger/identity/tree/feat/iota-v1-5-0-rc