### PR TITLE
BitstringStatusList v1 revocation mechanism and VC DM v2.0 `credentialStatus` fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev 
 product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.22", package = "product_common" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false }
-oqs = { version = "0.10", default-features = false, features = ["sigs", "std", "vendored"] }
+oqs = { version = "0.11", default-features = false, features = ["sigs", "std", "vendored"] }
 strum = { version = "0.25", default-features = false, features = ["std", "derive"] }
 thiserror = { version = "1.0", default-features = false }
 json-proof-token = { version = "0.4" }

--- a/bindings/wasm/identity_wasm/Cargo.toml
+++ b/bindings/wasm/identity_wasm/Cargo.toml
@@ -49,6 +49,7 @@ default-features = false
 features = [
   "iota-client",
   "revocation-bitmap",
+  "bitstring-status-list",
   "resolver",
   "domain-linkage",
   "sd-jwt",

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
@@ -17,19 +17,18 @@ import {
     Presentation,
     Resolver,
     Storage,
-    TransactionSigner,
 } from "@iota/identity-wasm/node";
 import { IotaClient } from "@iota/iota-sdk/client";
-import { NotarizationClient, NotarizationClientReadOnly, OnChainNotarization } from "@iota/notarization/node";
+import { OnChainNotarization } from "@iota/notarization/node";
 import {
     createDocumentForNetwork,
     getFundedClient,
     getMemstorage,
-    getNotarizationClient,
     IOTA_IDENTITY_PKG_ID,
     NETWORK_URL,
     TEST_GAS_BUDGET,
 } from "../util";
+import { getNotarizationClient } from "../notarization-utils";
 
 /**
  * This example shows how to create a Verifiable Presentation and validate it.

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
@@ -20,6 +20,7 @@ import {
 } from "@iota/identity-wasm/node";
 import { IotaClient } from "@iota/iota-sdk/client";
 import { OnChainNotarization } from "@iota/notarization/node";
+import { getNotarizationClient } from "../notarization-utils";
 import {
     createDocumentForNetwork,
     getFundedClient,
@@ -28,7 +29,6 @@ import {
     NETWORK_URL,
     TEST_GAS_BUDGET,
 } from "../util";
-import { getNotarizationClient } from "../notarization-utils";
 
 /**
  * This example shows how to create a Verifiable Presentation and validate it.

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/13_linked_verifiable_presentation.ts
@@ -25,12 +25,11 @@ import {
     createDocumentForNetwork,
     getFundedClient,
     getMemstorage,
+    getNotarizationClient,
     IOTA_IDENTITY_PKG_ID,
     NETWORK_URL,
     TEST_GAS_BUDGET,
 } from "../util";
-
-const IOTA_NOTARIZATION_PKG_ID = globalThis?.process?.env?.IOTA_NOTARIZATION_PKG_ID || "";
 
 /**
  * This example shows how to create a Verifiable Presentation and validate it.
@@ -150,18 +149,4 @@ async function makeVpJwt(didDocument: IotaDocument, storage: Storage, fragment: 
     );
 
     return jwtVp;
-}
-
-export async function getNotarizationClient(signer: TransactionSigner): Promise<NotarizationClient> {
-    if (!IOTA_NOTARIZATION_PKG_ID) {
-        throw new Error(`IOTA_NOTARIZATION_PKG_ID env variable must be provided to run the notarization examples`);
-    }
-
-    const iotaClient = new IotaClient({ url: NETWORK_URL });
-    const notarizationClientReadOnly = await NotarizationClientReadOnly.createWithPkgId(
-        iotaClient,
-        IOTA_NOTARIZATION_PKG_ID,
-    );
-
-    return await NotarizationClient.create(notarizationClientReadOnly, signer);
 }

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
@@ -12,13 +12,13 @@ import {
     JwtCredentialValidationOptions,
     JwtCredentialValidator,
     JwtVcV2,
-    Status,
     StatusCheck,
     StatusV2,
 } from "@iota/identity-wasm/node";
 import { IotaClient } from "@iota/iota-sdk/client";
 import { OnChainNotarization, State } from "@iota/notarization/node";
-import { createDocumentForNetwork, getFundedClient, getMemstorage, getNotarizationClient, NETWORK_URL } from "../util";
+import { createDocumentForNetwork, getFundedClient, getMemstorage, NETWORK_URL } from "../util";
+import { getNotarizationClient } from "../notarization-utils";
 
 export async function bitstringStatusListRevocation() {
     // Create new client to connect to IOTA network.

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
@@ -17,8 +17,8 @@ import {
 } from "@iota/identity-wasm/node";
 import { IotaClient } from "@iota/iota-sdk/client";
 import { OnChainNotarization, State } from "@iota/notarization/node";
-import { createDocumentForNetwork, getFundedClient, getMemstorage, NETWORK_URL } from "../util";
 import { getNotarizationClient } from "../notarization-utils";
+import { createDocumentForNetwork, getFundedClient, getMemstorage, NETWORK_URL } from "../util";
 
 export async function bitstringStatusListRevocation() {
     // Create new client to connect to IOTA network.

--- a/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
+++ b/bindings/wasm/identity_wasm/examples/src/1_advanced/14_bitstring_status_list_revocation.ts
@@ -1,0 +1,138 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    BitstringStatusListCredential,
+    BitstringStatusListEntry,
+    CredentialV2,
+    EdDSAJwsVerifier,
+    FailFast,
+    IrlResolver,
+    JwsSignatureOptions,
+    JwtCredentialValidationOptions,
+    JwtCredentialValidator,
+    JwtVcV2,
+    Status,
+    StatusCheck,
+    StatusV2,
+} from "@iota/identity-wasm/node";
+import { IotaClient } from "@iota/iota-sdk/client";
+import { OnChainNotarization, State } from "@iota/notarization/node";
+import { createDocumentForNetwork, getFundedClient, getMemstorage, getNotarizationClient, NETWORK_URL } from "../util";
+
+export async function bitstringStatusListRevocation() {
+    // Create new client to connect to IOTA network.
+    const iotaClient = new IotaClient({ url: NETWORK_URL });
+    const network = await iotaClient.getChainIdentifier();
+
+    // Create an identity for the issuer with one verification method `key-1`, and publish DID document for it.
+    const issuerStorage = getMemstorage();
+    const issuerClient = await getFundedClient(issuerStorage);
+    const [unpublishedIssuerDocument, issuerFragment] = await createDocumentForNetwork(issuerStorage, network);
+    const { output: issuerIdentity } = await issuerClient
+        .createIdentity(unpublishedIssuerDocument)
+        .finish()
+        .buildAndExecute(issuerClient);
+    let issuerDocument = issuerIdentity.didDocument();
+
+    // create holder account, create identity, and publish DID document for it.
+    const aliceStorage = getMemstorage();
+    const aliceClient = await getFundedClient(aliceStorage);
+    const [unpublishedAliceDocument, aliceFragment] = await createDocumentForNetwork(aliceStorage, network);
+    const { output: aliceIdentity } = await aliceClient
+        .createIdentity(unpublishedAliceDocument)
+        .finish()
+        .buildAndExecute(aliceClient);
+    const aliceDocument = aliceIdentity.didDocument();
+
+    // Issuer creates a BitstringStatusListCredential to revoke the VCs she issues.
+    let statusListCredential = new BitstringStatusListCredential({
+        issuer: issuerDocument.id().toString(),
+        statusPurposes: ["revocation"],
+    });
+    console.log(`New BitstringStatusListCredential: ${JSON.stringify(statusListCredential, null, 2)}`);
+    // Issuer signs the BitstringStatusListCredential and notarizes it on-chain.
+    let statusListCredentialJwt = await issuerDocument.createCredentialV2Jwt(
+        issuerStorage,
+        issuerFragment,
+        statusListCredential.toCredential(),
+        new JwsSignatureOptions(),
+    );
+    const notarizationClient = await getNotarizationClient(issuerClient.signer());
+    let notarizedBitstringStatusListCredential: OnChainNotarization = await notarizationClient.createDynamic()
+        .withStringState(statusListCredentialJwt.toString())
+        .finish()
+        .buildAndExecute(notarizationClient)
+        .then(res => res.output);
+    let credentialIrl = notarizedBitstringStatusListCredential.iotaResourceLocatorBuilder(notarizationClient.network())
+        .data();
+    console.log(`BitstringStatusListCredential has been notarized at: ${credentialIrl}`);
+
+    // Issuer now creates a credential for Alice, using BitstringStatusList to revoke it at any point in time.
+    const entry = new BitstringStatusListEntry({
+        statusListCredential: credentialIrl,
+        statusListIndex: 42,
+        statusPurpose: "revocation",
+    });
+    const unsignedVc = new CredentialV2({
+        id: "https://example.edu/credentials/3732",
+        type: "UniversityDegreeCredential",
+        issuer: issuerDocument.id(),
+        credentialSubject: {
+            id: aliceDocument.id(),
+            name: "Alice",
+            degreeName: "Bachelor of Science and Arts",
+            degreeType: "BachelorDegree",
+            GPA: "4.0",
+        },
+        credentialStatus: entry as unknown as StatusV2,
+    });
+    const aliceVcJwt = await issuerDocument.createCredentialV2Jwt(
+        issuerStorage,
+        issuerFragment,
+        unsignedVc,
+        new JwsSignatureOptions(),
+    );
+
+    // Validate the credential using the issuer's DID Document.
+    let jwtCredentialValidator = new JwtCredentialValidator(new EdDSAJwsVerifier());
+    jwtCredentialValidator.validateV2(
+        aliceVcJwt,
+        issuerDocument,
+        new JwtCredentialValidationOptions({ status: StatusCheck.SkipAll }),
+        FailFast.FirstError,
+    );
+    let status = statusListCredential.getEntryStatus(entry.statusListIndex, entry.statusPurpose);
+    console.assert(status.valid, "ooops credential is actually invalid");
+    console.log("Credential is valid!");
+
+    console.log("Issuer revokes credential...");
+    statusListCredential.setEntryStatus(entry, true);
+    statusListCredentialJwt = await issuerDocument.createCredentialV2Jwt(
+        issuerStorage,
+        issuerFragment,
+        statusListCredential.toCredential(),
+        new JwsSignatureOptions(),
+    );
+    await notarizationClient
+        .updateState(State.fromString(statusListCredentialJwt.toString()), notarizedBitstringStatusListCredential.id)
+        .buildAndExecute(notarizationClient);
+
+    // Now if a verifier resolves the status list and attempt to validate Alice's credential against
+    // it, the validation will fail as the credential has been revoked.
+    const irlResolver = new IrlResolver({ customNetworks: [{ chainId: network, endpoint: NETWORK_URL }] });
+    const resolvedStatusListJwt = await irlResolver.resolve(credentialIrl).then(value => new JwtVcV2(value));
+    // First the verifier validates the status list credential itself.
+    const decodedStatusListCredential = jwtCredentialValidator.validateV2(
+        resolvedStatusListJwt,
+        issuerDocument,
+        new JwtCredentialValidationOptions({ status: StatusCheck.SkipAll }), // We'll check it manually.
+        FailFast.FirstError,
+    ).intoCredential();
+    statusListCredential = BitstringStatusListCredential.fromCredential(decodedStatusListCredential);
+    // Now we verify the status of Alice's credential against it.
+    status = statusListCredential.getEntryStatus(entry.statusListIndex, entry.statusPurpose);
+    console.assert(!status.valid, "ooops credential is actually valid");
+
+    console.log("Alice credential has been revoked!");
+}

--- a/bindings/wasm/identity_wasm/examples/src/main.ts
+++ b/bindings/wasm/identity_wasm/examples/src/main.ts
@@ -15,6 +15,7 @@ import { sdJwtVc } from "./1_advanced/10_sd_jwt_vc";
 import { advancedTransaction } from "./1_advanced/11_advanced_transactions";
 import { iotaKeytoolIntegration } from "./1_advanced/12_iota_keytool_integration";
 import { linkedVp } from "./1_advanced/13_linked_verifiable_presentation";
+import { bitstringStatusListRevocation } from "./1_advanced/14_bitstring_status_list_revocation";
 import { customResolution } from "./1_advanced/4_custom_resolution";
 import { domainLinkage } from "./1_advanced/5_domain_linkage";
 import { sdJwt } from "./1_advanced/6_sd_jwt";
@@ -79,6 +80,8 @@ export async function main(example?: string) {
             return await iotaKeytoolIntegration();
         case "13_linked_verifiable_presentation":
             return await linkedVp();
+        case "14_bitstring_status_list":
+            return await bitstringStatusListRevocation();
         default:
             throw "Unknown example name: '" + argument + "'";
     }

--- a/bindings/wasm/identity_wasm/examples/src/notarization-utils.ts
+++ b/bindings/wasm/identity_wasm/examples/src/notarization-utils.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TransactionSigner } from "@iota/iota-interaction-ts/node/iota_interaction_ts";
+import { IotaClient } from "@iota/iota-sdk/client";
 import { NotarizationClient, NotarizationClientReadOnly } from "@iota/notarization/node";
 import { NETWORK_URL } from "./util";
-import { IotaClient } from "@iota/iota-sdk/client";
 
 export const IOTA_NOTARIZATION_PKG_ID = globalThis?.process?.env?.IOTA_NOTARIZATION_PKG_ID || "";
 

--- a/bindings/wasm/identity_wasm/examples/src/notarization-utils.ts
+++ b/bindings/wasm/identity_wasm/examples/src/notarization-utils.ts
@@ -1,0 +1,23 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { TransactionSigner } from "@iota/iota-interaction-ts/node/iota_interaction_ts";
+import { NotarizationClient, NotarizationClientReadOnly } from "@iota/notarization/node";
+import { NETWORK_URL } from "./util";
+import { IotaClient } from "@iota/iota-sdk/client";
+
+export const IOTA_NOTARIZATION_PKG_ID = globalThis?.process?.env?.IOTA_NOTARIZATION_PKG_ID || "";
+
+export async function getNotarizationClient(signer: TransactionSigner): Promise<NotarizationClient> {
+    if (!IOTA_NOTARIZATION_PKG_ID) {
+        throw new Error(`IOTA_NOTARIZATION_PKG_ID env variable must be provided to run the notarization examples`);
+    }
+
+    const iotaClient = new IotaClient({ url: NETWORK_URL });
+    const notarizationClientReadOnly = await NotarizationClientReadOnly.createWithPkgId(
+        iotaClient,
+        IOTA_NOTARIZATION_PKG_ID,
+    );
+
+    return await NotarizationClient.create(notarizationClientReadOnly, signer);
+}

--- a/bindings/wasm/identity_wasm/examples/src/util.ts
+++ b/bindings/wasm/identity_wasm/examples/src/util.ts
@@ -12,14 +12,17 @@ import {
     Storage,
     StorageSigner,
     Transaction,
+    TransactionSigner,
 } from "@iota/identity-wasm/node";
 import { CoreClientReadOnly } from "@iota/iota-interaction-ts/node/core_client";
 import { getFullnodeUrl, IotaClient, TransactionEffects } from "@iota/iota-sdk/client";
 import { getFaucetHost, requestIotaFromFaucetV0 } from "@iota/iota-sdk/faucet";
 import { IotaEvent } from "@iota/iota-sdk/src/client/types/generated";
 import { Transaction as SdkTransaction } from "@iota/iota-sdk/transactions";
+import { NotarizationClient, NotarizationClientReadOnly } from "@iota/notarization/node";
 
-export const IOTA_IDENTITY_PKG_ID = globalThis?.process?.env?.IOTA_IDENTITY_PKG_ID;
+export const IOTA_IDENTITY_PKG_ID = globalThis?.process?.env?.IOTA_IDENTITY_PKG_ID || "";
+export const IOTA_NOTARIZATION_PKG_ID = globalThis?.process?.env?.IOTA_NOTARIZATION_PKG_ID || "";
 export const NETWORK_NAME_FAUCET = globalThis?.process?.env?.NETWORK_NAME_FAUCET || "localnet";
 export const NETWORK_URL = getFullnodeUrl(NETWORK_NAME_FAUCET);
 
@@ -111,4 +114,18 @@ export class SendZeroCoinTx implements Transaction<string> {
     ): Promise<string> {
         return await this.apply(effects, client);
     }
+}
+
+export async function getNotarizationClient(signer: TransactionSigner): Promise<NotarizationClient> {
+    if (!IOTA_NOTARIZATION_PKG_ID) {
+        throw new Error(`IOTA_NOTARIZATION_PKG_ID env variable must be provided to run the notarization examples`);
+    }
+
+    const iotaClient = new IotaClient({ url: NETWORK_URL });
+    const notarizationClientReadOnly = await NotarizationClientReadOnly.createWithPkgId(
+        iotaClient,
+        IOTA_NOTARIZATION_PKG_ID,
+    );
+
+    return await NotarizationClient.create(notarizationClientReadOnly, signer);
 }

--- a/bindings/wasm/identity_wasm/examples/src/util.ts
+++ b/bindings/wasm/identity_wasm/examples/src/util.ts
@@ -12,17 +12,14 @@ import {
     Storage,
     StorageSigner,
     Transaction,
-    TransactionSigner,
 } from "@iota/identity-wasm/node";
 import { CoreClientReadOnly } from "@iota/iota-interaction-ts/node/core_client";
 import { getFullnodeUrl, IotaClient, TransactionEffects } from "@iota/iota-sdk/client";
 import { getFaucetHost, requestIotaFromFaucetV0 } from "@iota/iota-sdk/faucet";
 import { IotaEvent } from "@iota/iota-sdk/src/client/types/generated";
 import { Transaction as SdkTransaction } from "@iota/iota-sdk/transactions";
-import { NotarizationClient, NotarizationClientReadOnly } from "@iota/notarization/node";
 
 export const IOTA_IDENTITY_PKG_ID = globalThis?.process?.env?.IOTA_IDENTITY_PKG_ID || "";
-export const IOTA_NOTARIZATION_PKG_ID = globalThis?.process?.env?.IOTA_NOTARIZATION_PKG_ID || "";
 export const NETWORK_NAME_FAUCET = globalThis?.process?.env?.NETWORK_NAME_FAUCET || "localnet";
 export const NETWORK_URL = getFullnodeUrl(NETWORK_NAME_FAUCET);
 
@@ -114,18 +111,4 @@ export class SendZeroCoinTx implements Transaction<string> {
     ): Promise<string> {
         return await this.apply(effects, client);
     }
-}
-
-export async function getNotarizationClient(signer: TransactionSigner): Promise<NotarizationClient> {
-    if (!IOTA_NOTARIZATION_PKG_ID) {
-        throw new Error(`IOTA_NOTARIZATION_PKG_ID env variable must be provided to run the notarization examples`);
-    }
-
-    const iotaClient = new IotaClient({ url: NETWORK_URL });
-    const notarizationClientReadOnly = await NotarizationClientReadOnly.createWithPkgId(
-        iotaClient,
-        IOTA_NOTARIZATION_PKG_ID,
-    );
-
-    return await NotarizationClient.create(notarizationClientReadOnly, signer);
 }

--- a/bindings/wasm/identity_wasm/src/credential/credential_v2.rs
+++ b/bindings/wasm/identity_wasm/src/credential/credential_v2.rs
@@ -15,7 +15,7 @@ use identity_iota::credential::Policy;
 use identity_iota::credential::Proof;
 use identity_iota::credential::RefreshService;
 use identity_iota::credential::Schema;
-use identity_iota::credential::Status;
+use identity_iota::credential::StatusV2;
 use identity_iota::credential::Subject;
 use proc_typescript::typescript;
 use serde_json::Value;
@@ -33,7 +33,6 @@ use crate::credential::ArrayEvidence;
 use crate::credential::ArrayPolicy;
 use crate::credential::ArrayRefreshService;
 use crate::credential::ArraySchema;
-use crate::credential::ArrayStatus;
 use crate::credential::ArraySubject;
 use crate::credential::UrlOrIssuer;
 use crate::credential::WasmProof;
@@ -141,16 +140,13 @@ impl WasmCredentialV2 {
   }
 
   /// Returns a copy of the information used to determine the current status of the {@link Credential}.
-  #[wasm_bindgen(js_name = "credentialStatus")]
-  pub fn credential_status(&self) -> Result<ArrayStatus> {
-    self
-      .0
-      .credential_status
-      .iter()
-      .map(JsValue::from_serde)
-      .collect::<std::result::Result<js_sys::Array, _>>()
-      .wasm_result()
-      .map(|value| value.unchecked_into::<ArrayStatus>())
+  #[wasm_bindgen(js_name = "credentialStatus", unchecked_return_type = "StatusV2 | undefined | null")]
+  pub fn credential_status(&self) -> Result<Option<JsValue>> {
+    if let Some(status) = &self.0.credential_status {
+      Ok(Some(serde_wasm_bindgen::to_value(status)?))
+    } else {
+      Ok(None)
+    }
   }
 
   /// Returns a copy of the information used to assist in the enforcement of a specific {@link Credential} structure.
@@ -288,8 +284,8 @@ pub(crate) struct ICredentialHelperV2 {
   #[typescript(name = "validUntil", type = "Timestamp")]
   valid_until: Option<Timestamp>,
   /// Information used to determine the current status of the {@link Credential}.
-  #[typescript(name = "credentialStatus", type = "Status")]
-  credential_status: Option<Status>,
+  #[typescript(name = "credentialStatus", type = "StatusV2")]
+  credential_status: Option<StatusV2>,
   /// Information used to assist in the enforcement of a specific {@link Credential} structure.
   #[typescript(name = "credentialSchema", type = "Schema | Array<Schema>")]
   credential_schema: Option<OneOrMany<Schema>>,
@@ -367,7 +363,7 @@ impl TryFrom<ICredentialV2> for CredentialBuilder {
       builder = builder.expiration_date(valid_until);
     }
     if let Some(credential_status) = credential_status {
-      builder = builder.status(credential_status);
+      builder = builder.status_v2(credential_status);
     }
     if let Some(credential_schema) = credential_schema {
       for schema in credential_schema.into_vec() {

--- a/bindings/wasm/identity_wasm/src/credential/jwt.rs
+++ b/bindings/wasm/identity_wasm/src/credential/jwt.rs
@@ -51,6 +51,11 @@ pub struct WasmJwtVcV2(pub(crate) JwtVcV2);
 
 #[wasm_bindgen(js_class = JwtVcV2)]
 impl WasmJwtVcV2 {
+  #[wasm_bindgen(constructor)]
+  pub fn new(jwt: &str) -> Result<Self, JsError> {
+    Ok(Self(JwtVcV2::parse(jwt)?))
+  }
+
   #[allow(clippy::inherent_to_string)]
   #[wasm_bindgen(js_name = toString)]
   pub fn to_string(&self) -> String {

--- a/bindings/wasm/identity_wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
+++ b/bindings/wasm/identity_wasm/src/credential/jwt_credential_validation/jwt_credential_validator.rs
@@ -17,6 +17,7 @@ use crate::credential::jwt::WasmJwtVcV2;
 use crate::credential::options::WasmStatusCheck;
 use crate::credential::revocation::status_list_2021::WasmStatusList2021Credential;
 use crate::credential::CredentialAny;
+use crate::credential::WasmCredentialAny;
 use crate::credential::WasmDecodedJwtCredential;
 use crate::credential::WasmDecodedJwtCredentialV2;
 use crate::credential::WasmFailFast;
@@ -211,33 +212,58 @@ impl WasmJwtCredentialValidator {
 
   /// Validate that the credential expires on or after the specified timestamp.
   #[wasm_bindgen(js_name = checkExpiresOnOrAfter)]
-  pub fn check_expires_on_or_after(credential: &CredentialAny, timestamp: &WasmTimestamp) -> Result<()> {
-    JwtCredentialValidatorUtils::check_expires_on_or_after(&*credential.try_to_dyn_credential()?, timestamp.0)
-      .wasm_result()
+  pub fn check_expires_on_or_after(credential: &WasmCredentialAny, timestamp: &WasmTimestamp) -> Result<()> {
+    let credential = CredentialAny::try_from(credential.clone())?;
+    match credential {
+      CredentialAny::CredentialV1(c) => {
+        JwtCredentialValidatorUtils::check_expires_on_or_after(&c, timestamp.0).map_err(JsError::from)?
+      }
+      CredentialAny::CredentialV2(c) => {
+        JwtCredentialValidatorUtils::check_expires_on_or_after(&c, timestamp.0).map_err(JsError::from)?
+      }
+    }
+
+    Ok(())
   }
 
   /// Validate that the credential is issued on or before the specified timestamp.
   #[wasm_bindgen(js_name = checkIssuedOnOrBefore)]
-  pub fn check_issued_on_or_before(credential: &CredentialAny, timestamp: &WasmTimestamp) -> Result<()> {
-    JwtCredentialValidatorUtils::check_issued_on_or_before(&*credential.try_to_dyn_credential()?, timestamp.0)
-      .wasm_result()
+  pub fn check_issued_on_or_before(credential: &WasmCredentialAny, timestamp: &WasmTimestamp) -> Result<()> {
+    let credential = CredentialAny::try_from(credential.clone())?;
+    match credential {
+      CredentialAny::CredentialV1(c) => {
+        JwtCredentialValidatorUtils::check_issued_on_or_before(&c, timestamp.0).map_err(JsError::from)?
+      }
+      CredentialAny::CredentialV2(c) => {
+        JwtCredentialValidatorUtils::check_issued_on_or_before(&c, timestamp.0).map_err(JsError::from)?
+      }
+    }
+
+    Ok(())
   }
 
   /// Validate that the relationship between the `holder` and the credential subjects is in accordance with
   /// `relationship`. The `holder` parameter is expected to be the URL of the holder.
   #[wasm_bindgen(js_name = checkSubjectHolderRelationship)]
   pub fn check_subject_holder_relationship(
-    credential: &CredentialAny,
+    credential: &WasmCredentialAny,
     holder: &str,
     relationship: WasmSubjectHolderRelationship,
   ) -> Result<()> {
     let holder: Url = Url::parse(holder).wasm_result()?;
-    JwtCredentialValidatorUtils::check_subject_holder_relationship(
-      &*credential.try_to_dyn_credential()?,
-      &holder,
-      relationship.into(),
-    )
-    .wasm_result()
+    let credential = CredentialAny::try_from(credential.clone())?;
+    match credential {
+      CredentialAny::CredentialV1(c) => {
+        JwtCredentialValidatorUtils::check_subject_holder_relationship(&c, &holder, relationship.into())
+          .map_err(JsError::from)?
+      }
+      CredentialAny::CredentialV2(c) => {
+        JwtCredentialValidatorUtils::check_subject_holder_relationship(&c, &holder, relationship.into())
+          .map_err(JsError::from)?
+      }
+    }
+
+    Ok(())
   }
 
   /// Checks whether the credential status has been revoked.
@@ -246,7 +272,7 @@ impl WasmJwtCredentialValidator {
   #[wasm_bindgen(js_name = checkStatus)]
   #[allow(non_snake_case)]
   pub fn check_status(
-    credential: &CredentialAny,
+    credential: &WasmCredentialAny,
     trustedIssuers: &ArrayIToCoreDocument,
     statusCheck: WasmStatusCheck,
   ) -> Result<()> {
@@ -257,23 +283,41 @@ impl WasmJwtCredentialValidator {
       .collect::<Result<Vec<ImportedDocumentReadGuard<'_>>>>(
     )?;
     let status_check: StatusCheck = statusCheck.into();
-    JwtCredentialValidatorUtils::check_status(&*credential.try_to_dyn_credential()?, &trusted_issuers, status_check)
-      .wasm_result()
+    let credential = CredentialAny::try_from(credential.clone())?;
+    match credential {
+      CredentialAny::CredentialV1(c) => {
+        JwtCredentialValidatorUtils::check_status(&c, &trusted_issuers, status_check).map_err(JsError::from)?
+      }
+      CredentialAny::CredentialV2(c) => {
+        JwtCredentialValidatorUtils::check_status(&c, &trusted_issuers, status_check).map_err(JsError::from)?
+      }
+    }
+
+    Ok(())
   }
 
   /// Checks whether the credential status has been revoked using `StatusList2021`.
   #[wasm_bindgen(js_name = checkStatusWithStatusList2021)]
   pub fn check_status_with_status_list_2021(
-    credential: &CredentialAny,
+    credential: &WasmCredentialAny,
     status_list: &WasmStatusList2021Credential,
     status_check: WasmStatusCheck,
-  ) -> Result<()> {
-    JwtCredentialValidatorUtils::check_status_with_status_list_2021(
-      &*credential.try_to_dyn_credential()?,
-      &status_list.inner,
-      status_check.into(),
-    )
-    .wasm_result()
+  ) -> std::result::Result<(), JsError> {
+    let credential = CredentialAny::try_from(credential.clone())?;
+    match credential {
+      CredentialAny::CredentialV1(c) => JwtCredentialValidatorUtils::check_status_with_status_list_2021::<Object, _>(
+        &c,
+        &status_list.inner,
+        status_check.into(),
+      )?,
+      CredentialAny::CredentialV2(c) => JwtCredentialValidatorUtils::check_status_with_status_list_2021::<Object, _>(
+        &c,
+        &status_list.inner,
+        status_check.into(),
+      )?,
+    }
+
+    Ok(())
   }
 
   /// Utility for extracting the issuer field of a {@link Credential} as a DID.
@@ -282,10 +326,18 @@ impl WasmJwtCredentialValidator {
   ///
   /// Fails if the issuer field is not a valid DID.
   #[wasm_bindgen(js_name = extractIssuer)]
-  pub fn extract_issuer(credential: &CredentialAny) -> Result<WasmCoreDID> {
-    JwtCredentialValidatorUtils::extract_issuer::<CoreDID, Object>(&*credential.try_to_dyn_credential()?)
-      .map(WasmCoreDID::from)
-      .wasm_result()
+  pub fn extract_issuer(credential: &WasmCredentialAny) -> std::result::Result<WasmCoreDID, JsError> {
+    let credential = CredentialAny::try_from(credential.clone())?;
+    let did = match credential {
+      CredentialAny::CredentialV1(c) => {
+        JwtCredentialValidatorUtils::extract_issuer::<CoreDID, Object>(&c).map(WasmCoreDID)?
+      }
+      CredentialAny::CredentialV2(c) => {
+        JwtCredentialValidatorUtils::extract_issuer::<CoreDID, Object>(&c).map(WasmCoreDID)?
+      }
+    };
+
+    Ok(did)
   }
 
   /// Utility for extracting the issuer field of a credential in JWT representation as DID.

--- a/bindings/wasm/identity_wasm/src/credential/jwt_credential_validation/jwt_credential_validator_hybrid.rs
+++ b/bindings/wasm/identity_wasm/src/credential/jwt_credential_validation/jwt_credential_validator_hybrid.rs
@@ -3,6 +3,7 @@
 
 use identity_iota::core::Object;
 use identity_iota::core::Url;
+use identity_iota::credential::Credential;
 use identity_iota::credential::JwtCredentialValidatorHybrid;
 use identity_iota::credential::JwtCredentialValidatorUtils;
 use identity_iota::credential::StatusCheck;
@@ -183,7 +184,7 @@ impl WasmJwtCredentialValidatorHybrid {
     status_list: &WasmStatusList2021Credential,
     status_check: WasmStatusCheck,
   ) -> Result<()> {
-    JwtCredentialValidatorUtils::check_status_with_status_list_2021(
+    JwtCredentialValidatorUtils::check_status_with_status_list_2021::<Object, Credential>(
       &credential.0,
       &status_list.inner,
       status_check.into(),

--- a/bindings/wasm/identity_wasm/src/credential/mod.rs
+++ b/bindings/wasm/identity_wasm/src/credential/mod.rs
@@ -3,11 +3,10 @@
 
 #![allow(clippy::module_inception)]
 
-use identity_iota::core::Object;
 use identity_iota::credential::Credential;
-use identity_iota::credential::CredentialT;
 use identity_iota::credential::CredentialV2;
 use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsError;
 use wasm_bindgen::JsValue;
 
 pub use self::credential::WasmCredential;
@@ -58,21 +57,23 @@ extern "C" {
   /// A VC Credential. Either {@link Credential} or {@link CredentialV2}.
   #[derive(Clone)]
   #[wasm_bindgen(typescript_type = "Credential | CredentialV2")]
-  pub type CredentialAny;
+  pub type WasmCredentialAny;
 
   #[wasm_bindgen(method, js_name = toJSON)]
-  pub fn to_json(this: &CredentialAny) -> JsValue;
+  pub fn to_json(this: &WasmCredentialAny) -> JsValue;
 }
 
-impl CredentialAny {
-  pub(crate) fn try_to_dyn_credential(&self) -> Result<Box<dyn CredentialT<Properties = Object> + Sync>, JsValue> {
-    let json_repr = self.to_json();
-    serde_wasm_bindgen::from_value::<Credential>(json_repr.clone())
-      .map(|c| Box::new(c) as Box<dyn CredentialT<Properties = Object> + Sync>)
-      .or_else(|_| {
-        serde_wasm_bindgen::from_value::<CredentialV2>(json_repr)
-          .map(|c| Box::new(c) as Box<dyn CredentialT<Properties = Object> + Sync>)
-      })
-      .map_err(|e| e.into())
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+pub(crate) enum CredentialAny {
+  CredentialV1(Credential),
+  CredentialV2(CredentialV2),
+}
+
+impl TryFrom<WasmCredentialAny> for CredentialAny {
+  type Error = JsError;
+  fn try_from(value: WasmCredentialAny) -> Result<Self, Self::Error> {
+    let json_repr = value.to_json();
+    Ok(serde_wasm_bindgen::from_value(json_repr)?)
   }
 }

--- a/bindings/wasm/identity_wasm/src/credential/revocation/status_list_2021/entry.rs
+++ b/bindings/wasm/identity_wasm/src/credential/revocation/status_list_2021/entry.rs
@@ -35,8 +35,8 @@ impl WasmStatusList2021Entry {
 
   /// Returns this `credentialStatus`'s `id`.
   #[wasm_bindgen]
-  pub fn id(&self) -> String {
-    self.0.id().to_string()
+  pub fn id(&self) -> Option<String> {
+    self.0.id().map(|url| url.to_string())
   }
 
   /// Returns the purpose of this entry.

--- a/bindings/wasm/identity_wasm/src/credential/types.rs
+++ b/bindings/wasm/identity_wasm/src/credential/types.rs
@@ -46,6 +46,9 @@ extern "C" {
 
   #[wasm_bindgen(typescript_type = "Status")]
   pub type WasmStatus;
+
+  #[wasm_bindgen(typescript_type = "StatusV2")]
+  pub type WasmStatusV2;
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -128,7 +131,20 @@ interface Status {
   readonly type: string;
   /** Additional properties of the credential status. */
   readonly [properties: string]: unknown;
-}"#;
+}
+
+/** Information used to determine the current status of a {@link CredentialV2}.
+
+[More Info](https://www.w3.org/TR/vc-data-model-2.0/#status) */
+interface StatusV2 {
+  /** A URL identifying the credential status. */
+  readonly id?: string;
+  /** The type of the credential status. */
+  readonly type: string | string[];
+  /** Additional properties of the credential status. */
+  readonly [properties: string]: unknown;
+}
+"#;
 
 #[wasm_bindgen(typescript_custom_section)]
 const I_SUBJECT: &'static str = r#"

--- a/bindings/wasm/identity_wasm/src/revocation/bitstring_status_list.rs
+++ b/bindings/wasm/identity_wasm/src/revocation/bitstring_status_list.rs
@@ -19,7 +19,8 @@ use crate::credential::WasmCredentialV2;
 
 #[wasm_bindgen(typescript_custom_section)]
 const ENTRY_INTERFACE: &str = r#"
-export type StatusPurpose = "refresh" | "revocation" | "suspension" | "message" | string;
+export type BitstringStatusPurpose = "refresh" | "revocation" | "suspension" | "message" | string;
+
 export type StatusMessage = {
   status: string;
   message: string;
@@ -27,15 +28,36 @@ export type StatusMessage = {
 
 export interface BitstringStatusListEntryParams {
   id?: string;
-  statusPurpose: StatusPurpose;
+  statusPurpose: BitstringStatusPurpose;
   statusListIndex: string | number;
   statusListCredential: string;
   statusMessage?: string[];
   statusReference?: string | string[];
 }
+
+export interface BitstringStatusListCredentialParams {
+  id?: string;
+  validFrom?: string;
+  validUntil?: string;
+  issuer: string;
+  context?: string[] | object[];
+  type?: string[];
+  proof?: object;
+  numberOfEntries?: number;
+  statusPurposes: BitstringStatusPurpose | BitstringStatusPurpose[];
+  statusMessages?: StatusMessage[];
+  ttl?: number;
+}
+
+export interface EntryStatus {
+  status: number;
+  valid: boolean;
+  purpose: BitstringStatusPurpose;
+  message?: StatusMessage;
+}
 "#;
 
-#[wasm_bindgen(js_name = BitstringStatusListEntry)]
+#[wasm_bindgen(js_name = BitstringStatusListEntry, inspectable)]
 pub struct WasmBitstringStatusListEntry(pub(crate) BitstringStatusListEntry);
 
 #[wasm_bindgen(js_class = BitstringStatusListEntry)]
@@ -61,7 +83,7 @@ impl WasmBitstringStatusListEntry {
     self.0.type_().to_string()
   }
 
-  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "StatusPurpose")]
+  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "BitstringStatusPurpose")]
   pub fn status_purpose(&self) -> String {
     self.0.status_purpose().to_string()
   }
@@ -90,12 +112,9 @@ impl WasmBitstringStatusListEntry {
   pub fn status_reference(&self) -> Vec<String> {
     self.0.status_reference().iter().map(|url| url.to_string()).collect()
   }
-
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<String, JsError> {
-    Ok(serde_json::to_string(&self.0)?)
-  }
 }
+
+impl_wasm_json!(WasmBitstringStatusListEntry, BitstringStatusListEntry);
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -151,29 +170,9 @@ impl WasmStatusMessage {
 
 #[wasm_bindgen(typescript_custom_section)]
 const CREDENTIAL_PARAMS: &str = r#"
-export interface BitstringStatusListCredentialParams {
-  id?: string;
-  validFrom?: string;
-  validUntil?: string;
-  issuer: string;
-  context?: string[] | object[];
-  type?: string[];
-  proof?: object;
-  numberOfEntries?: number;
-  statusPurposes: StatusPurpose | StatusPurposes[];
-  statusMessages?: StatusMessage[];
-  ttl?: number;
-}
-
-export interface EntryStatus {
-  status: number;
-  valid: boolean;
-  purpose: StatusPurpose;
-  message?: StatusMessage;
-}
 "#;
 
-#[wasm_bindgen(js_name = BitstringStatusListCredential)]
+#[wasm_bindgen(js_name = BitstringStatusListCredential, inspectable)]
 pub struct WasmBitstringStatusListCredential(pub(crate) BitstringStatusListCredential);
 
 #[wasm_bindgen(js_class = BitstringStatusListCredential)]
@@ -205,7 +204,7 @@ impl WasmBitstringStatusListCredential {
     WasmCredentialV2(self.0.as_ref().clone())
   }
 
-  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "StatusPurpose[]")]
+  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "BitstringStatusPurpose[]")]
   pub fn status_purpose(&self) -> Vec<String> {
     self.0.purposes().iter().map(|purpose| purpose.to_string()).collect()
   }
@@ -235,8 +234,8 @@ impl WasmBitstringStatusListCredential {
   #[wasm_bindgen(js_name = setEntryStatus)]
   pub fn set_entry_status(
     &mut self,
-    #[wasm_bindgen(unchecked_param_type = "bool | StatusMessage")] entry: &WasmBitstringStatusListEntry,
-    value: &JsValue,
+    entry: &WasmBitstringStatusListEntry,
+    #[wasm_bindgen(unchecked_param_type = "bool | StatusMessage")] value: &JsValue,
   ) -> Result<(), JsError> {
     let status_value = if let Some(flag) = value.as_bool() {
       StatusValue::Flag(flag)
@@ -248,12 +247,9 @@ impl WasmBitstringStatusListCredential {
 
     Ok(())
   }
-
-  #[wasm_bindgen(js_name = toJSON)]
-  pub fn to_json(&self) -> Result<String, JsError> {
-    Ok(serde_json::to_string(&self.0)?)
-  }
 }
+
+impl_wasm_json!(WasmBitstringStatusListCredential, BitstringStatusListCredential);
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -333,11 +329,15 @@ where
       v.parse::<usize>().map_err(E::custom)
     }
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
     where
       E: serde::de::Error,
     {
-      Ok(v as usize)
+      if v >= 0 {
+        Ok(v as usize)
+      } else {
+        Err(E::invalid_value(serde::de::Unexpected::Signed(v), &"unsigned integer"))
+      }
     }
   }
 

--- a/bindings/wasm/identity_wasm/src/revocation/bitstring_status_list.rs
+++ b/bindings/wasm/identity_wasm/src/revocation/bitstring_status_list.rs
@@ -1,0 +1,345 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use identity_iota::core::Context;
+use identity_iota::core::OneOrMany;
+use identity_iota::core::Timestamp;
+use identity_iota::core::Url;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListCredential;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListEntry;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+use identity_iota::credential::bitstring_status_list_v1::StatusMessage;
+use identity_iota::credential::bitstring_status_list_v1::StatusPurpose;
+use identity_iota::credential::bitstring_status_list_v1::StatusValue;
+use identity_iota::credential::Proof;
+use wasm_bindgen::prelude::*;
+
+use crate::credential::WasmCredentialV2;
+
+#[wasm_bindgen(typescript_custom_section)]
+const ENTRY_INTERFACE: &str = r#"
+export type StatusPurpose = "refresh" | "revocation" | "suspension" | "message" | string;
+export type StatusMessage = {
+  status: string;
+  message: string;
+};
+
+export interface BitstringStatusListEntryParams {
+  id?: string;
+  statusPurpose: StatusPurpose;
+  statusListIndex: string | number;
+  statusListCredential: string;
+  statusMessage?: string[];
+  statusReference?: string | string[];
+}
+"#;
+
+#[wasm_bindgen(js_name = BitstringStatusListEntry)]
+pub struct WasmBitstringStatusListEntry(pub(crate) BitstringStatusListEntry);
+
+#[wasm_bindgen(js_class = BitstringStatusListEntry)]
+impl WasmBitstringStatusListEntry {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    #[wasm_bindgen(unchecked_param_type = "BitstringStatusListEntryParams")] params: JsValue,
+  ) -> Result<Self, JsValue> {
+    let params: EntryParamsHelper = serde_wasm_bindgen::from_value(params)?;
+    BitstringStatusListEntryBuilder::from(params)
+      .build()
+      .map(Self)
+      .map_err(|err| JsValue::from_str(&err.to_string()))
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn id(&self) -> Option<String> {
+    self.0.id().map(|id| id.to_string())
+  }
+
+  #[wasm_bindgen(getter, js_name = "type")]
+  pub fn type_(&self) -> String {
+    self.0.type_().to_string()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "StatusPurpose")]
+  pub fn status_purpose(&self) -> String {
+    self.0.status_purpose().to_string()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusListIndex)]
+  pub fn status_list_index(&self) -> usize {
+    self.0.status_list_index()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusListCredential)]
+  pub fn status_list_credential(&self) -> String {
+    self.0.status_list_credential().to_string()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusSize)]
+  pub fn status_size(&self) -> usize {
+    self.0.status_size()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusMessage, unchecked_return_type = "StatusMessage[]")]
+  pub fn status_message(&self) -> Vec<WasmStatusMessage> {
+    self.0.status_message().iter().cloned().map(WasmStatusMessage).collect()
+  }
+
+  #[wasm_bindgen(getter, js_name = statusReference)]
+  pub fn status_reference(&self) -> Vec<String> {
+    self.0.status_reference().iter().map(|url| url.to_string()).collect()
+  }
+
+  #[wasm_bindgen(js_name = toJSON)]
+  pub fn to_json(&self) -> Result<String, JsError> {
+    Ok(serde_json::to_string(&self.0)?)
+  }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EntryParamsHelper {
+  id: Option<Url>,
+  status_purpose: StatusPurpose,
+  #[serde(deserialize_with = "number_from_either_string_or_number")]
+  status_list_index: usize,
+  status_list_credential: Url,
+  #[serde(default)]
+  status_message: Vec<String>,
+  #[serde(default)]
+  status_reference: OneOrMany<Url>,
+}
+
+impl From<EntryParamsHelper> for BitstringStatusListEntryBuilder {
+  fn from(params: EntryParamsHelper) -> Self {
+    let mut builder = BitstringStatusListEntryBuilder::default()
+      .status_purpose(params.status_purpose)
+      .credential(params.status_list_credential)
+      .index(params.status_list_index)
+      .references(params.status_reference)
+      .ordered_messages(params.status_message);
+
+    if let Some(id) = params.id {
+      builder = builder.id(id);
+    }
+
+    builder
+  }
+}
+
+#[wasm_bindgen(js_name = StatusMessage, skip_typescript)]
+pub struct WasmStatusMessage(pub(crate) StatusMessage);
+
+#[wasm_bindgen(js_class = StatusMessage)]
+impl WasmStatusMessage {
+  #[wasm_bindgen(constructor)]
+  pub fn new(#[wasm_bindgen(unchecked_param_type = "StatusMessage")] value: JsValue) -> Result<Self, JsValue> {
+    Ok(serde_wasm_bindgen::from_value(value).map(Self)?)
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn status(&self) -> String {
+    format!("{:#x}", self.0.status)
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn message(&self) -> String {
+    self.0.message.clone()
+  }
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const CREDENTIAL_PARAMS: &str = r#"
+export interface BitstringStatusListCredentialParams {
+  id?: string;
+  validFrom?: string;
+  validUntil?: string;
+  issuer: string;
+  context?: string[] | object[];
+  type?: string[];
+  proof?: object;
+  numberOfEntries?: number;
+  statusPurposes: StatusPurpose | StatusPurposes[];
+  statusMessages?: StatusMessage[];
+  ttl?: number;
+}
+
+export interface EntryStatus {
+  status: number;
+  valid: boolean;
+  purpose: StatusPurpose;
+  message?: StatusMessage;
+}
+"#;
+
+#[wasm_bindgen(js_name = BitstringStatusListCredential)]
+pub struct WasmBitstringStatusListCredential(pub(crate) BitstringStatusListCredential);
+
+#[wasm_bindgen(js_class = BitstringStatusListCredential)]
+impl WasmBitstringStatusListCredential {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    #[wasm_bindgen(unchecked_param_type = "BitstringStatusListCredentialParams")] params: JsValue,
+  ) -> Result<Self, JsValue> {
+    let params: CredentialParamsHelper = serde_wasm_bindgen::from_value(params)?;
+    let credential = BitstringStatusListCredentialBuilder::from(params)
+      .build()
+      .map_err(|e| JsError::from(e))?;
+
+    Ok(Self(credential))
+  }
+
+  #[wasm_bindgen(js_name = fromCredential)]
+  pub fn from_credential(credential: &WasmCredentialV2) -> Result<Self, JsError> {
+    Ok(Self(credential.clone().0.try_into()?))
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn id(&self) -> Option<String> {
+    self.0.id().map(Url::to_string)
+  }
+
+  #[wasm_bindgen(js_name = toCredential)]
+  pub fn to_credential(&self) -> WasmCredentialV2 {
+    WasmCredentialV2(self.0.as_ref().clone())
+  }
+
+  #[wasm_bindgen(getter, js_name = statusPurpose, unchecked_return_type = "StatusPurpose[]")]
+  pub fn status_purpose(&self) -> Vec<String> {
+    self.0.purposes().iter().map(|purpose| purpose.to_string()).collect()
+  }
+
+  #[wasm_bindgen(getter, js_name = encodedList)]
+  pub fn encoded_list(&self) -> String {
+    self.0.encoded_list().to_string()
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn ttl(&self) -> Option<u64> {
+    self.0.ttl()
+  }
+
+  #[wasm_bindgen(getter, js_name = entrySize)]
+  pub fn entry_size(&self) -> u32 {
+    self.0.entry_size() as u32
+  }
+
+  #[wasm_bindgen(js_name = getEntryStatus, unchecked_return_type = "EntryStatus")]
+  pub fn get_entry_status(&self, index: usize, purpose: &str) -> Result<JsValue, JsError> {
+    let purpose = purpose.parse()?;
+    let status = self.0.entry(index, &purpose)?;
+    Ok(serde_wasm_bindgen::to_value(&status)?)
+  }
+
+  #[wasm_bindgen(js_name = setEntryStatus)]
+  pub fn set_entry_status(
+    &mut self,
+    #[wasm_bindgen(unchecked_param_type = "bool | StatusMessage")] entry: &WasmBitstringStatusListEntry,
+    value: &JsValue,
+  ) -> Result<(), JsError> {
+    let status_value = if let Some(flag) = value.as_bool() {
+      StatusValue::Flag(flag)
+    } else {
+      StatusValue::Message(&serde_wasm_bindgen::from_value(value.clone())?)
+    };
+
+    self.0.update().set_entry(&entry.0, status_value)?;
+
+    Ok(())
+  }
+
+  #[wasm_bindgen(js_name = toJSON)]
+  pub fn to_json(&self) -> Result<String, JsError> {
+    Ok(serde_json::to_string(&self.0)?)
+  }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialParamsHelper {
+  id: Option<Url>,
+  valid_from: Option<Timestamp>,
+  valid_until: Option<Timestamp>,
+  issuer: Url,
+  #[serde(default)]
+  context: Vec<Context>,
+  #[serde(default)]
+  type_: Vec<String>,
+  proof: Option<Proof>,
+  number_of_entries: Option<usize>,
+  status_purposes: OneOrMany<StatusPurpose>,
+  #[serde(default)]
+  status_messages: Vec<StatusMessage>,
+  ttl: Option<u64>,
+}
+
+impl From<CredentialParamsHelper> for BitstringStatusListCredentialBuilder {
+  fn from(params: CredentialParamsHelper) -> Self {
+    let mut builder = BitstringStatusListCredentialBuilder::default()
+      .issuer(params.issuer)
+      .status_purposes(params.status_purposes)
+      .status_messages(params.status_messages);
+
+    if let Some(id) = params.id {
+      builder = builder.id(id);
+    }
+    if let Some(valid_from) = params.valid_from {
+      builder = builder.valid_from(valid_from);
+    }
+    if let Some(valid_until) = params.valid_until {
+      builder = builder.valid_until(valid_until);
+    }
+    builder = params
+      .context
+      .into_iter()
+      .fold(builder, |builder, ctx| builder.context(ctx));
+    builder = params
+      .type_
+      .into_iter()
+      .fold(builder, |builder, ty| builder.add_type(ty));
+
+    if let Some(proof) = params.proof {
+      builder = builder.proof(proof);
+    }
+    if let Some(number_of_entries) = params.number_of_entries {
+      builder = builder.number_of_entries(number_of_entries);
+    }
+    if let Some(ttl) = params.ttl {
+      builder = builder.ttl(ttl);
+    }
+
+    builder
+  }
+}
+
+fn number_from_either_string_or_number<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+  D: serde::Deserializer<'de>,
+{
+  use serde::de::Visitor;
+
+  struct EitherStringOrNumber;
+  impl<'de> Visitor<'de> for EitherStringOrNumber {
+    type Value = usize;
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+      formatter.write_str("a string-encoded unsigned number or an unsigned number")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+      E: serde::de::Error,
+    {
+      v.parse::<usize>().map_err(E::custom)
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+      E: serde::de::Error,
+    {
+      Ok(v as usize)
+    }
+  }
+
+  deserializer.deserialize_any(EitherStringOrNumber)
+}

--- a/bindings/wasm/identity_wasm/src/revocation/mod.rs
+++ b/bindings/wasm/identity_wasm/src/revocation/mod.rs
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod bitmap;
+mod bitstring_status_list;
 
 pub use self::bitmap::WasmRevocationBitmap;
+pub use bitstring_status_list::*;

--- a/examples/1_advanced/14_bitstring_status_list.rs
+++ b/examples/1_advanced/14_bitstring_status_list.rs
@@ -129,8 +129,8 @@ where
   let jwt_status_list_credential = issuer_document
     .create_credential_v2_jwt(
       &status_list_credential.clone().into(),
-      &issuer_storage,
-      &issuer_fragment,
+      issuer_storage,
+      issuer_fragment,
       &JwsSignatureOptions::default(),
     )
     .await?;
@@ -161,8 +161,8 @@ where
   let jwt = issuer_document
     .create_credential_v2_jwt(
       &status_list_credential.clone().into(),
-      &issuer_storage,
-      &issuer_fragment,
+      issuer_storage,
+      issuer_fragment,
       &JwsSignatureOptions::default(),
     )
     .await?;

--- a/examples/1_advanced/14_bitstring_status_list.rs
+++ b/examples/1_advanced/14_bitstring_status_list.rs
@@ -1,0 +1,251 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context as _;
+use examples::create_did_document;
+use examples::get_funded_client;
+use examples::get_iota_endpoint;
+use examples::get_memstorage;
+use examples::get_notarization_client;
+use examples::MemStorage;
+use identity_eddsa_verifier::EdDSAJwsVerifier;
+use identity_iota::core::FromJson as _;
+use identity_iota::core::Object;
+use identity_iota::core::ToJson;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListCredential;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListEntry;
+use identity_iota::credential::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+use identity_iota::credential::bitstring_status_list_v1::StatusPurpose;
+use identity_iota::credential::CredentialBuilder;
+use identity_iota::credential::CredentialV2;
+use identity_iota::credential::DecodedJwtCredentialV2;
+use identity_iota::credential::FailFast;
+use identity_iota::credential::FailFast::FirstError;
+use identity_iota::credential::JwtCredentialValidationOptions;
+use identity_iota::credential::JwtCredentialValidator;
+use identity_iota::credential::JwtVcV2;
+use identity_iota::credential::StatusCheck;
+use identity_iota::credential::Subject;
+use identity_iota::did::DID;
+use identity_iota::iota::IotaDID;
+use identity_iota::iota::IotaDocument;
+use identity_iota::iota_interaction::IotaKeySignature;
+use identity_storage::JwkDocumentExt as _;
+use identity_storage::JwsSignatureOptions;
+use iota_caip::iota::resolver::Resolver as IotaResourceResolver;
+use iota_caip::iota::IotaNetwork;
+use iota_sdk_types::ObjectId;
+use notarization::core::types::OnChainNotarization;
+use notarization::core::types::State;
+use notarization::NotarizationClient;
+use product_common::core_client::CoreClient as _;
+use secret_storage::Signer;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+  let issuer_storage = get_memstorage()?;
+  let issuer_client = get_funded_client(&issuer_storage).await?;
+  let (issuer_document, issuer_vm_fragment) = create_did_document(&issuer_client, &issuer_storage).await?;
+  let notarization_client = get_notarization_client(issuer_client.signer().clone()).await?;
+
+  let holder_storage = get_memstorage()?;
+  let holder_client = get_funded_client(&holder_storage).await?;
+  let (holder_document, _holder_vm_fragment) = create_did_document(&holder_client, &holder_storage).await?;
+
+  // Create and notarize a Bitstring Status List Credential to handle VC revocations.
+  let (notarized_status_list, mut status_list_credential) = create_notarized_bitstring_status_list(
+    &issuer_document,
+    &issuer_storage,
+    &issuer_vm_fragment,
+    &notarization_client,
+  )
+  .await?;
+  let status_list_irl = notarized_status_list
+    .iota_resource_locator_builder(issuer_client.network())
+    .data();
+
+  // Create a Bitstring Status List entry referencing the notarized status list credential.
+  let status_list_entry = BitstringStatusListEntryBuilder::new()
+    .credential(status_list_irl.into())
+    .index(42)
+    .status_purpose(StatusPurpose::Revocation)
+    .build()?;
+
+  let revocable_credential = make_revocable_credential(
+    &issuer_document,
+    &issuer_storage,
+    &issuer_vm_fragment,
+    holder_document.id(),
+    &status_list_entry,
+  )
+  .await?;
+
+  // Validate credential, ensuring it is not revoked.
+  println!("Validating credential...");
+  let options = JwtCredentialValidationOptions::default().status_check(StatusCheck::SkipAll);
+  let DecodedJwtCredentialV2 { credential, .. } = JwtCredentialValidator::with_signature_verifier(
+    EdDSAJwsVerifier::default(),
+  )
+  .validate_v2(&revocable_credential, &issuer_document, &options, FirstError)?;
+  assert!(check_credential_status(&credential, issuer_client.network(), &issuer_document).await?);
+  println!("Credential is valid and not revoked!");
+
+  // Revoke the credential.
+  status_list_credential.update().set_entry(&status_list_entry, true)?;
+  update_notarized_bitstring_status_list(
+    &issuer_document,
+    &issuer_storage,
+    &issuer_vm_fragment,
+    *notarized_status_list.id.object_id(),
+    &status_list_credential,
+    &notarization_client,
+  )
+  .await?;
+  println!("Issuer revokes the credential...");
+
+  // Validate the credential status again, this time ensuring it is revoked.
+  println!("Validating credential...");
+  assert!(!check_credential_status(&credential, issuer_client.network(), &issuer_document).await?);
+  println!("Invalid credential status detected! Credential has been revoked.");
+
+  Ok(())
+}
+
+async fn create_notarized_bitstring_status_list<S>(
+  issuer_document: &IotaDocument,
+  issuer_storage: &MemStorage,
+  issuer_fragment: &str,
+  notarization_client: &NotarizationClient<S>,
+) -> anyhow::Result<(OnChainNotarization, BitstringStatusListCredential)>
+where
+  S: Signer<IotaKeySignature> + Sync,
+{
+  let status_list_credential = BitstringStatusListCredentialBuilder::new()
+    .issuer(issuer_document.id().to_url())
+    .status_purposes(StatusPurpose::Revocation)
+    .build()?;
+  let jwt_status_list_credential = issuer_document
+    .create_credential_v2_jwt(
+      &status_list_credential.clone().into(),
+      &issuer_storage,
+      &issuer_fragment,
+      &JwsSignatureOptions::default(),
+    )
+    .await?;
+
+  Ok((
+    notarization_client
+      .create_dynamic_notarization()
+      .with_string_state(jwt_status_list_credential.as_str().to_owned(), None)
+      .finish()
+      .build_and_execute(notarization_client)
+      .await?
+      .output,
+    status_list_credential,
+  ))
+}
+
+async fn update_notarized_bitstring_status_list<S>(
+  issuer_document: &IotaDocument,
+  issuer_storage: &MemStorage,
+  issuer_fragment: &str,
+  notarization_id: ObjectId,
+  status_list_credential: &BitstringStatusListCredential,
+  notarization_client: &NotarizationClient<S>,
+) -> anyhow::Result<()>
+where
+  S: Signer<IotaKeySignature> + Sync,
+{
+  let jwt = issuer_document
+    .create_credential_v2_jwt(
+      &status_list_credential.clone().into(),
+      &issuer_storage,
+      &issuer_fragment,
+      &JwsSignatureOptions::default(),
+    )
+    .await?;
+
+  notarization_client
+    .update_state(State::from_string(jwt.as_str().to_owned(), None), notarization_id)
+    .build_and_execute(notarization_client)
+    .await?;
+
+  Ok(())
+}
+
+async fn make_revocable_credential(
+  issuer_document: &IotaDocument,
+  issuer_storage: &MemStorage,
+  issuer_fragment: &str,
+  holder_id: &IotaDID,
+  status_entry: &BitstringStatusListEntry,
+) -> anyhow::Result<JwtVcV2> {
+  let credential = CredentialBuilder::new(Object::new())
+    .id("https://example.org/credentials/1872".parse()?)
+    .issuer(issuer_document.id().to_url())
+    .subject(Subject::from_json_value(json!({
+      "id": holder_id.as_str(),
+      "name": "Alice",
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts",
+      },
+      "GPA": "4.0",
+    }))?)
+    .status(status_entry.clone())
+    .build_v2()?;
+
+  println!("Issuing credential: {}", credential.to_json_pretty()?);
+
+  Ok(
+    issuer_document
+      .create_credential_v2_jwt(
+        &credential,
+        issuer_storage,
+        issuer_fragment,
+        &JwsSignatureOptions::default(),
+      )
+      .await?,
+  )
+}
+
+async fn check_credential_status(
+  credential: &CredentialV2,
+  network: &str,
+  issuer_document: &IotaDocument,
+) -> anyhow::Result<bool> {
+  let Some(status) = &credential.credential_status else {
+    return Ok(true);
+  };
+  let status_entry = BitstringStatusListEntry::try_from(status)?;
+  let custom_network = IotaNetwork::custom(network).expect("valid IOTA network");
+  let iota_resource_resolver =
+    IotaResourceResolver::new_with_custom_networks(vec![(custom_network, get_iota_endpoint())]);
+
+  let jwt_status_list_credential = iota_resource_resolver
+    .resolve(status_entry.status_list_credential())
+    .await?
+    .as_str()
+    .context("failed to resolve status list credential")
+    .and_then(|jwt| JwtVcV2::parse(jwt).context("failed to parse status list credential"))?;
+  let status_list_credential = JwtCredentialValidator::with_signature_verifier(EdDSAJwsVerifier::default())
+    .validate_v2(
+      &jwt_status_list_credential,
+      issuer_document,
+      &JwtCredentialValidationOptions::default(),
+      FailFast::FirstError,
+    )
+    .context("failed to validate status list credential")
+    .and_then(|decoded| {
+      BitstringStatusListCredential::try_from(decoded.credential)
+        .context("failed to convert to BitstringStatusListCredential")
+    })?;
+
+  Ok(
+    status_list_credential
+      .entry(status_entry.status_list_index(), status_entry.status_purpose())?
+      .valid,
+  )
+}

--- a/examples/1_advanced/14_bitstring_status_list.rs
+++ b/examples/1_advanced/14_bitstring_status_list.rs
@@ -194,7 +194,7 @@ async fn make_revocable_credential(
       },
       "GPA": "4.0",
     }))?)
-    .status(status_entry.clone())
+    .status_v2(status_entry.clone())
     .build_v2()?;
 
   println!("Issuing credential: {}", credential.to_json_pretty()?);
@@ -219,7 +219,7 @@ async fn check_credential_status(
   let Some(status) = &credential.credential_status else {
     return Ok(true);
   };
-  let status_entry = BitstringStatusListEntry::try_from(status)?;
+  let status_entry = BitstringStatusListEntry::try_from(status.clone())?;
   let custom_network = IotaNetwork::custom(network).expect("valid IOTA network");
   let iota_resource_resolver =
     IotaResourceResolver::new_with_custom_networks(vec![(custom_network, get_iota_endpoint())]);

--- a/examples/1_advanced/8_status_list_2021.rs
+++ b/examples/1_advanced/8_status_list_2021.rs
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
     FailFast::FirstError,
   )?;
   // Check manually for revocation
-  JwtCredentialValidatorUtils::check_status_with_status_list_2021(
+  JwtCredentialValidatorUtils::check_status_with_status_list_2021::<Object, _>(
     &credential,
     &status_list_credential,
     StatusCheck::Strict,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,6 +37,7 @@ features = [
   "revocation-bitmap",
   "sd-jwt",
   "status-list-2021",
+  "bitstring-status-list",
   "keytool",
   "hybrid-liboqs",
   "gas-station",
@@ -142,3 +143,7 @@ name = "12_advanced_transactions"
 [[example]]
 path = "1_advanced/13_iota_keytool_integration.rs"
 name = "13_iota_keytool_integration"
+
+[[example]]
+path = "1_advanced/14_bitstring_status_list.rs"
+name = "14_bitstring_status_list"

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -13,6 +13,7 @@ description = "An implementation of the Verifiable Credentials standard."
 [dependencies]
 anyhow = { version = "1" }
 async-trait = { version = "0.1.64", default-features = false }
+bitvec = "1.1.1"
 bls12_381_plus = { workspace = true, optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
@@ -24,6 +25,7 @@ indexmap = { version = "2.0", default-features = false, features = ["std", "serd
 itertools = { version = "0.11", default-features = false, features = ["use_std"] }
 json-proof-token = { workspace = true, optional = true }
 jsonschema = { version = "0.19", optional = true, default-features = false }
+multibase = "0.9.3"
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["default-tls", "json", "stream"], optional = true }
 roaring = { version = "0.10.2", default-features = false, features = ["serde"], optional = true }

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -13,7 +13,7 @@ description = "An implementation of the Verifiable Credentials standard."
 [dependencies]
 anyhow = { version = "1" }
 async-trait = { version = "0.1.64", default-features = false }
-bitvec = { version = "1.1.1", optional = true }
+bitvec = { version = "1", optional = true }
 bls12_381_plus = { workspace = true, optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
@@ -25,7 +25,7 @@ indexmap = { version = "2.0", default-features = false, features = ["std", "serd
 itertools = { version = "0.11", default-features = false, features = ["use_std"] }
 json-proof-token = { workspace = true, optional = true }
 jsonschema = { version = "0.19", optional = true, default-features = false }
-multibase = { version = "0.9.3", optional = true }
+multibase = { version = "0.9", optional = true }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["default-tls", "json", "stream"], optional = true }
 roaring = { version = "0.10.2", default-features = false, features = ["serde"], optional = true }

--- a/identity_credential/Cargo.toml
+++ b/identity_credential/Cargo.toml
@@ -13,7 +13,7 @@ description = "An implementation of the Verifiable Credentials standard."
 [dependencies]
 anyhow = { version = "1" }
 async-trait = { version = "0.1.64", default-features = false }
-bitvec = "1.1.1"
+bitvec = { version = "1.1.1", optional = true }
 bls12_381_plus = { workspace = true, optional = true }
 flate2 = { version = "1.0.28", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
@@ -25,7 +25,7 @@ indexmap = { version = "2.0", default-features = false, features = ["std", "serd
 itertools = { version = "0.11", default-features = false, features = ["use_std"] }
 json-proof-token = { workspace = true, optional = true }
 jsonschema = { version = "0.19", optional = true, default-features = false }
-multibase = "0.9.3"
+multibase = { version = "0.9.3", optional = true }
 once_cell = { version = "1.18", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["default-tls", "json", "stream"], optional = true }
 roaring = { version = "0.10.2", default-features = false, features = ["serde"], optional = true }
@@ -81,5 +81,6 @@ jpt-bbs-plus = [
   "dep:futures",
 ]
 hybrid = ["credential", "validator"]
+bitstring-status-list = ["revocation-bitmap", "dep:multibase", "dep:bitvec"]
 [lints]
 workspace = true

--- a/identity_credential/src/credential/builder.rs
+++ b/identity_credential/src/credential/builder.rs
@@ -7,6 +7,7 @@ use identity_core::common::Timestamp;
 use identity_core::common::Url;
 use identity_core::common::Value;
 
+use crate::credential::status::StatusV2;
 use crate::credential::Credential;
 use crate::credential::CredentialV2;
 use crate::credential::Evidence;
@@ -16,7 +17,6 @@ use crate::credential::RefreshService;
 use crate::credential::Schema;
 use crate::credential::Status;
 use crate::credential::Subject;
-use crate::credential::status::StatusV2;
 use crate::error::Result;
 
 use super::Proof;

--- a/identity_credential/src/credential/builder.rs
+++ b/identity_credential/src/credential/builder.rs
@@ -16,6 +16,7 @@ use crate::credential::RefreshService;
 use crate::credential::Schema;
 use crate::credential::Status;
 use crate::credential::Subject;
+use crate::credential::status::StatusV2;
 use crate::error::Result;
 
 use super::Proof;
@@ -31,6 +32,7 @@ pub struct CredentialBuilder<T = Object> {
   pub(crate) issuance_date: Option<Timestamp>,
   pub(crate) expiration_date: Option<Timestamp>,
   pub(crate) status: Option<Status>,
+  pub(crate) status_v2: Option<StatusV2>,
   pub(crate) schema: Vec<Schema>,
   pub(crate) refresh_service: Vec<RefreshService>,
   pub(crate) terms_of_use: Vec<Policy>,
@@ -52,6 +54,7 @@ impl<T> CredentialBuilder<T> {
       issuance_date: None,
       expiration_date: None,
       status: None,
+      status_v2: None,
       schema: Vec::new(),
       refresh_service: Vec::new(),
       terms_of_use: Vec::new(),
@@ -138,6 +141,15 @@ impl<T> CredentialBuilder<T> {
   #[must_use]
   pub fn status(mut self, value: impl Into<Status>) -> Self {
     self.status = Some(value.into());
+    self
+  }
+
+  /// Adds a value to the `credentialStatus` set.
+  /// ## Notes
+  /// Use this method only when constructing a VC using data model v2.0.
+  #[must_use]
+  pub fn status_v2(mut self, value: impl Into<StatusV2>) -> Self {
+    self.status_v2 = Some(value.into());
     self
   }
 

--- a/identity_credential/src/credential/credential.rs
+++ b/identity_credential/src/credential/credential.rs
@@ -230,6 +230,7 @@ where
   T: ToOwned<Owned = T> + serde::Serialize + serde::de::DeserializeOwned,
 {
   type Properties = T;
+  type Status = Status;
 
   fn base_context(&self) -> &'static Context {
     Self::base_context()

--- a/identity_credential/src/credential/credential_v2.rs
+++ b/identity_credential/src/credential/credential_v2.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
+use crate::credential::status::StatusV2;
 use crate::credential::CredentialBuilder;
 use crate::credential::CredentialSealed;
 use crate::credential::CredentialT;
@@ -26,7 +27,6 @@ use crate::credential::Policy;
 use crate::credential::Proof;
 use crate::credential::RefreshService;
 use crate::credential::Schema;
-use crate::credential::Status;
 use crate::credential::Subject;
 use crate::error::Error;
 use crate::error::Result;
@@ -71,7 +71,7 @@ pub struct Credential<T = Object> {
   pub valid_until: Option<Timestamp>,
   /// Information used to determine the current status of the `Credential`.
   #[serde(default, rename = "credentialStatus", skip_serializing_if = "Option::is_none")]
-  pub credential_status: Option<Status>,
+  pub credential_status: Option<StatusV2>,
   /// Information used to assist in the enforcement of a specific `Credential` structure.
   #[serde(default, rename = "credentialSchema", skip_serializing_if = "OneOrMany::is_empty")]
   pub credential_schema: OneOrMany<Schema>,
@@ -117,6 +117,8 @@ impl<T> Credential<T> {
       builder.types.insert(0, Self::base_type().to_owned());
     }
 
+    let status = builder.status.map(StatusV2::from).or(builder.status_v2);
+
     let this = Self {
       context: OneOrMany::Many(builder.context),
       id: builder.id,
@@ -125,7 +127,7 @@ impl<T> Credential<T> {
       issuer: builder.issuer.ok_or(Error::MissingIssuer)?,
       valid_from: builder.issuance_date.unwrap_or_default(),
       valid_until: builder.expiration_date,
-      credential_status: builder.status,
+      credential_status: status,
       credential_schema: builder.schema.into(),
       refresh_service: builder.refresh_service.into(),
       terms_of_use: builder.terms_of_use.into(),
@@ -185,6 +187,7 @@ where
   T: Clone + Serialize + DeserializeOwned,
 {
   type Properties = T;
+  type Status = StatusV2;
 
   fn base_context(&self) -> &'static Context {
     Self::base_context()
@@ -218,7 +221,7 @@ where
     &self.properties
   }
 
-  fn status(&self) -> Option<&Status> {
+  fn status(&self) -> Option<&StatusV2> {
     self.credential_status.as_ref()
   }
 

--- a/identity_credential/src/credential/mod.rs
+++ b/identity_credential/src/credential/mod.rs
@@ -34,6 +34,8 @@ use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Timestamp;
 
+pub use crate::credential::status::StatusT;
+
 pub use self::builder::CredentialBuilder;
 pub use self::credential::Credential;
 pub use self::evidence::Evidence;
@@ -56,6 +58,7 @@ pub use self::revocation_bitmap_status::try_index_to_u32;
 pub use self::revocation_bitmap_status::RevocationBitmapStatus;
 pub use self::schema::Schema;
 pub use self::status::Status;
+pub use self::status::StatusV2;
 pub use self::subject::Subject;
 pub use credential_v2::Credential as CredentialV2;
 pub use enveloped_credential::*;
@@ -73,6 +76,8 @@ trait CredentialSealed {}
 pub trait CredentialT: CredentialSealed {
   /// The type of the custom claims.
   type Properties;
+  /// The type of this credential status.
+  type Status: StatusT;
 
   /// The Credential's context.
   fn context(&self) -> &OneOrMany<Context>;
@@ -87,7 +92,7 @@ pub trait CredentialT: CredentialSealed {
   /// The Credential's expiration date, if any.
   fn valid_until(&self) -> Option<Timestamp>;
   /// The Credential's validity status, if any.
-  fn status(&self) -> Option<&Status>;
+  fn status(&self) -> Option<&Self::Status>;
   /// The Credential's custom properties.
   fn properties(&self) -> &Self::Properties;
   /// Whether the Credential's `nonTransferable` property is set.

--- a/identity_credential/src/credential/revocation_bitmap_status.rs
+++ b/identity_credential/src/credential/revocation_bitmap_status.rs
@@ -9,6 +9,7 @@ use identity_core::common::Value;
 use identity_did::DIDUrl;
 
 use crate::credential::Status;
+use crate::credential::StatusV2;
 use crate::error::Error;
 use crate::error::Result;
 
@@ -122,9 +123,23 @@ impl TryFrom<Status> for RevocationBitmapStatus {
   }
 }
 
+impl TryFrom<StatusV2> for RevocationBitmapStatus {
+  type Error = Error;
+  fn try_from(value: StatusV2) -> Result<Self, Self::Error> {
+    let status = Status::try_from(value).map_err(|e| Error::InvalidStatus(e.to_string()))?;
+    status.try_into()
+  }
+}
+
 impl From<RevocationBitmapStatus> for Status {
   fn from(status: RevocationBitmapStatus) -> Self {
     status.0
+  }
+}
+
+impl From<RevocationBitmapStatus> for StatusV2 {
+  fn from(value: RevocationBitmapStatus) -> Self {
+    value.0.into()
   }
 }
 

--- a/identity_credential/src/credential/status.rs
+++ b/identity_credential/src/credential/status.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use identity_core::common::OneOrMany;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -34,6 +35,93 @@ impl<T> Status<T> {
   pub fn new_with_properties(id: Url, type_: String, properties: T) -> Self {
     Self { id, type_, properties }
   }
+}
+
+/// VC Data Model 2.0 [credential status](https://www.w3.org/TR/vc-data-model-2.0/#status).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct StatusV2<T = Object> {
+  /// Optional ID for this `credentialStatus`.
+  pub id: Option<Url>,
+  /// Types of status information.
+  #[serde(rename = "type")]
+  pub type_: OneOrMany<String>,
+  /// Properties depending on type.
+  #[serde(flatten)]
+  pub properties: T,
+}
+
+impl<T> From<Status<T>> for StatusV2<T> {
+  fn from(value: Status<T>) -> Self {
+    Self {
+      id: Some(value.id),
+      type_: OneOrMany::One(value.type_),
+      properties: value.properties,
+    }
+  }
+}
+
+impl<T> TryFrom<StatusV2<T>> for Status<T> {
+  type Error = StatusConversionError;
+  fn try_from(value: StatusV2<T>) -> Result<Self, Self::Error> {
+    Ok(Self {
+      id: value.id.ok_or(StatusConversionError::MissingId)?,
+      type_: value.type_.into_vec().swap_remove(0),
+      properties: value.properties,
+    })
+  }
+}
+
+/// The error resulting from a failed conversion of a [`StatusV2`] into a [`Status`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StatusConversionError {
+  /// Property `id` is missing.
+  #[error("missing property `id`")]
+  MissingId,
+}
+
+impl<T> Sealed for Status<T> {}
+impl<T> StatusT for Status<T> {
+  type Properties = T;
+  fn id(&self) -> Option<&Url> {
+    Some(&self.id)
+  }
+  fn type_(&self) -> &[String] {
+    std::slice::from_ref(&self.type_)
+  }
+  fn properties(&self) -> &Self::Properties {
+    &self.properties
+  }
+}
+
+impl<T> Sealed for StatusV2<T> {}
+impl<T> StatusT for StatusV2<T> {
+  type Properties = T;
+  fn id(&self) -> Option<&Url> {
+    self.id.as_ref()
+  }
+  fn type_(&self) -> &[String] {
+    self.type_.as_slice()
+  }
+  fn properties(&self) -> &Self::Properties {
+    &self.properties
+  }
+}
+
+trait Sealed {}
+
+/// A `credentialStatus`.
+#[allow(private_bounds)]
+pub trait StatusT: Sealed {
+  /// Unknown properties type.
+  type Properties;
+
+  /// `credentialStatus.id` property.
+  fn id(&self) -> Option<&Url>;
+  /// `credentialStatus.type` property.
+  fn type_(&self) -> &[String];
+  /// All other properties of the status object.
+  fn properties(&self) -> &Self::Properties;
 }
 
 #[cfg(test)]

--- a/identity_credential/src/revocation/bitstring_status_list_v1/credential.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/credential.rs
@@ -1,0 +1,1372 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types for the [`BitstringStatusListCredential`], the [Verifiable Credential](CredentialV2) that hosts the
+//! statuses referenced by [`BitstringStatusListEntry`] objects, as defined in
+//! [Bitstring Status List Credential](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential).
+//!
+//! Such a credential carries a bitstring in which each entry occupies [`entry_size`] bits: the entry
+//! referenced by a `statusListIndex` of `i` is found at bit `i * entry_size`, counting from the left-most
+//! (most significant) bit of the bitstring. Issuers publish the bitstring GZIP-compressed and
+//! multibase-encoded in `credentialSubject.encodedList`, which is what [`encoded_list`] returns.
+//!
+//! An issuer creates a list with [`BitstringStatusListCredentialBuilder`], hosts it at the URL its entries
+//! point to, and changes the status of an entry through [`update`]:
+//!
+//! ```
+//! use identity_core::common::Url;
+//! use identity_credential::credential::Issuer;
+//! use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+//! use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+//! use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+//!
+//! let list_url = Url::parse("https://example.com/credentials/status/3")?;
+//!
+//! // The issuer hosts a status list credential at `list_url`...
+//! let mut status_list = BitstringStatusListCredentialBuilder::new()
+//!   .id(list_url.clone())
+//!   .issuer(Issuer::Url(Url::parse("did:example:12345")?))
+//!   .status_purposes(StatusPurpose::Revocation)
+//!   .build()?;
+//!
+//! // ...and references one of its entries from the credentials it issues.
+//! let entry = BitstringStatusListEntryBuilder::new()
+//!   .credential(list_url)
+//!   .index(94567)
+//!   .status_purpose(StatusPurpose::Revocation)
+//!   .build()?;
+//!
+//! assert!(status_list.entry(94567, &StatusPurpose::Revocation)?.valid);
+//!
+//! // Revoking the referenced credential sets its bit and re-encodes the list.
+//! status_list.update().set_entry(&entry, true)?;
+//! assert!(!status_list.entry(94567, &StatusPurpose::Revocation)?.valid);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! [`entry_size`]: BitstringStatusListCredential::entry_size
+//! [`encoded_list`]: BitstringStatusListCredential::encoded_list
+//! [`update`]: BitstringStatusListCredential::update
+
+use std::ops::Range;
+
+use bitvec::bitvec;
+use bitvec::field::BitField;
+use bitvec::order::Msb0;
+use bitvec::vec::BitVec;
+use identity_core::common::Context;
+use identity_core::common::Object;
+use identity_core::common::OneOrMany;
+use identity_core::common::Timestamp;
+use identity_core::common::Url;
+use serde::Deserialize;
+use serde::Serialize;
+use serde::Serializer;
+use serde_json::Value;
+
+use crate::credential::CredentialBuilder;
+use crate::credential::CredentialV2;
+use crate::credential::Issuer;
+use crate::credential::Proof;
+use crate::credential::Subject;
+use crate::revocation::bitstring_status_list_v1::entry::BitstringStatusListEntry;
+use crate::revocation::bitstring_status_list_v1::StatusMessage;
+use crate::revocation::bitstring_status_list_v1::StatusPurpose;
+use crate::revocation::bitstring_status_list_v1::StatusValue;
+
+/// Type of a `BitstringStatusList` VC.
+pub const CREDENTIAL_TYPE: &str = "BitstringStatusListCredential";
+/// `credentialSubject.type` of a `BitstringStatusList` VC.
+pub const CREDENTIAL_SUBJECT_TYPE: &str = "BitstringStatusList";
+/// The number of entries the specification mandates as a minimum, i.e. a 16KB bitstring.
+const MINIMUM_NUMBER_OF_ENTRIES: usize = 16 * 1024 * 8;
+/// The greatest [`entry_size`](BitstringStatusListCredential::entry_size) a list may declare: a
+/// status is read into a `usize`, and the number of values it can take — `2^entry_size` — must
+/// itself be representable.
+const MAXIMUM_ENTRY_SIZE: usize = usize::BITS as usize - 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialSubject {
+  #[serde(rename = "type")]
+  type_: String,
+  status_purpose: OneOrMany<StatusPurpose>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  status_size: Option<usize>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  status_messages: Vec<StatusMessage>,
+  encoded_list: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  ttl: Option<u64>,
+}
+
+impl CredentialSubject {
+  /// The number of bits each entry occupies; `statusSize` defaults to 1.
+  fn entry_size(&self) -> usize {
+    self.status_size.unwrap_or(1)
+  }
+}
+
+impl Default for CredentialSubject {
+  fn default() -> Self {
+    Self {
+      type_: CREDENTIAL_SUBJECT_TYPE.to_owned(),
+      status_purpose: OneOrMany::default(),
+      status_size: None,
+      status_messages: Vec::default(),
+      encoded_list: String::default(),
+      ttl: None,
+    }
+  }
+}
+
+/// A parsed [Bitstring Status List Credential](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential),
+/// i.e. a [`CredentialV2`] of type [`CREDENTIAL_TYPE`] whose single credential subject holds the encoded
+/// bitstring.
+///
+/// Deserializing one validates its structure and decodes its `encodedList`; see
+/// [`InvalidCredentialError`] for the ways in which that can fail. Serializing one yields the wrapped
+/// Verifiable Credential unchanged, which is also reachable through [`AsRef<CredentialV2>`](AsRef) and
+/// [`From<BitstringStatusListCredential>`](CredentialV2).
+///
+/// A verifier that has fetched the credential referenced by a `statusListIndex` reads that entry's status
+/// with [`entry`](Self::entry):
+///
+/// ```
+/// use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredential;
+/// use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+///
+/// // The example credential from the specification.
+/// let json = r#"{
+///   "@context": ["https://www.w3.org/ns/credentials/v2"],
+///   "id": "https://example.com/credentials/status/3",
+///   "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+///   "issuer": "did:example:12345",
+///   "validFrom": "2021-04-05T14:27:40Z",
+///   "credentialSubject": {
+///     "id": "https://example.com/status/3#list",
+///     "type": "BitstringStatusList",
+///     "statusPurpose": "revocation",
+///     "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+///   }
+/// }"#;
+///
+/// let status_list: BitstringStatusListCredential = serde_json::from_str(json)?;
+///
+/// assert_eq!(status_list.purposes(), [StatusPurpose::Revocation]);
+/// assert!(status_list.entry(94567, &StatusPurpose::Revocation)?.valid);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "CredentialV2")]
+pub struct BitstringStatusListCredential {
+  credential: CredentialV2,
+  subject: CredentialSubject,
+  decoded_list: BitVec<u8, Msb0>,
+}
+
+impl BitstringStatusListCredential {
+  /// Returns the credential's ID, i.e. the URL the entries of this list are expected to reference.
+  pub fn id(&self) -> Option<&Url> {
+    self.credential.id.as_ref()
+  }
+
+  /// Returns the purposes this status list serves, i.e. what the bits of its entries encode.
+  ///
+  /// Only entries whose
+  /// [`status_purpose`](crate::revocation::bitstring_status_list_v1::entry::BitstringStatusListEntry::status_purpose)
+  /// is one of these can be read or written.
+  pub fn purposes(&self) -> &[StatusPurpose] {
+    self.subject.status_purpose.as_slice()
+  }
+
+  /// Returns `credentialSubject.encodedList`: the credential's bitstring, GZIP-compressed and
+  /// multibase-encoded.
+  ///
+  /// It is kept in sync with the statuses set through [`update`](Self::update).
+  pub fn encoded_list(&self) -> &str {
+    &self.subject.encoded_list
+  }
+
+  /// Returns the optional `credentialSubject.ttl`: how long, in milliseconds, a cached copy of this
+  /// credential may be used before it should be fetched again.
+  pub fn ttl(&self) -> Option<u64> {
+    self.subject.ttl
+  }
+
+  /// Returns the number of bits each entry of this list occupies, i.e. `credentialSubject.statusSize`,
+  /// which defaults to 1.
+  ///
+  /// An entry's status is therefore a value in `0..2^entry_size`, and lists with an `entry_size` greater
+  /// than 1 name each of those values through a [`StatusMessage`].
+  pub fn entry_size(&self) -> usize {
+    self.subject.entry_size()
+  }
+
+  /// Returns the status of the entry at `index` for the given `purpose`.
+  ///
+  /// ```
+  /// # use identity_core::common::Url;
+  /// # use identity_credential::credential::Issuer;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+  /// # let status_list = BitstringStatusListCredentialBuilder::new()
+  /// #   .issuer(Issuer::Url(Url::parse("did:example:12345")?))
+  /// #   .status_purposes(StatusPurpose::Revocation)
+  /// #   .build()?;
+  /// let status = status_list.entry(94567, &StatusPurpose::Revocation)?;
+  ///
+  /// // Nothing has been revoked in this list yet.
+  /// assert_eq!(status.status, 0);
+  /// assert!(status.valid);
+  /// # Ok::<(), Box<dyn std::error::Error>>(())
+  /// ```
+  ///
+  /// ## Errors
+  /// - [EntryStatusError::PurposeMismatch] if this list does not serve `purpose`;
+  /// - [EntryStatusError::OutOfRange] if `index` is beyond the end of the list;
+  /// - [EntryStatusError::InvalidStatusMessage] if `purpose` is [`StatusPurpose::Message`] but the entry's value is not
+  ///   one of the credential's `statusMessages`.
+  pub fn entry(&self, index: usize, purpose: &StatusPurpose) -> Result<EntryStatus<'_>, EntryStatusError> {
+    if !self.subject.status_purpose.contains(purpose) {
+      return Err(EntryStatusError::PurposeMismatch(purpose.clone()));
+    }
+
+    let range = self.entry_range(index)?;
+    // `entry_size` is `1..=MAXIMUM_ENTRY_SIZE` for any credential that can be built or parsed, so
+    // the region is neither empty nor wider than the `usize` it is read into.
+    let status: usize = self.decoded_list[range].load_be();
+    let mut result = EntryStatus {
+      status,
+      valid: status == 0,
+      purpose: purpose.clone(),
+      message: None,
+    };
+
+    if purpose == &StatusPurpose::Message {
+      let message = self
+        .subject
+        .status_messages
+        .iter()
+        .find(|message| message.status == status)
+        .ok_or(EntryStatusError::InvalidStatusMessage(status))?;
+      result.message = Some(message);
+    }
+
+    Ok(result)
+  }
+
+  /// Returns a handle through which the statuses of this credential's entries can be set.
+  ///
+  /// The credential's [`encoded_list`](Self::encoded_list) is recomputed when the returned
+  /// [`StatusListMut`] is dropped, and only if a status actually changed.
+  pub fn update(&mut self) -> StatusListMut<'_> {
+    StatusListMut {
+      credential: self,
+      dirty: false,
+    }
+  }
+
+  /// Returns the range of bits the entry at `index` occupies.
+  fn entry_range(&self, index: usize) -> Result<Range<usize>, IndexOutOfBounds> {
+    let entry_size = self.entry_size();
+    let left = index.checked_mul(entry_size).ok_or(IndexOutOfBounds(index))?;
+    let right = left.checked_add(entry_size).ok_or(IndexOutOfBounds(index))?;
+
+    if self.decoded_list.len() < right {
+      return Err(IndexOutOfBounds(index));
+    }
+
+    Ok(left..right)
+  }
+
+  /// Re-encodes the bitstring into `encodedList`, the two copies of which — the parsed subject's and
+  /// the wrapped credential's — must always agree.
+  fn sync_encoded_list(&mut self) {
+    let encoded_list = encode_status_list(&self.decoded_list);
+
+    self
+      .credential
+      .credential_subject
+      .get_mut(0)
+      .expect("a status list credential has exactly one credential subject")
+      .properties
+      .insert("encodedList".to_owned(), encoded_list.clone().into());
+    self.subject.encoded_list = encoded_list;
+  }
+}
+
+impl Serialize for BitstringStatusListCredential {
+  /// Serializes the wrapped Verifiable Credential, unchanged.
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    self.credential.serialize(serializer)
+  }
+}
+
+impl AsRef<CredentialV2> for BitstringStatusListCredential {
+  fn as_ref(&self) -> &CredentialV2 {
+    &self.credential
+  }
+}
+
+impl TryFrom<CredentialV2> for BitstringStatusListCredential {
+  type Error = InvalidCredentialError;
+  fn try_from(credential: CredentialV2) -> Result<Self, Self::Error> {
+    // Ensure Credential has type "BitstringStatusListCredential".
+    if !credential.types.iter().any(|ty| ty.as_str() == CREDENTIAL_TYPE) {
+      return Err(InvalidCredentialError::InvalidCredentialType);
+    }
+
+    // A status list credential describes exactly one status list. Note that a single subject may be
+    // encoded either on its own or as a one-element array.
+    let [subject] = credential.credential_subject.as_slice() else {
+      return Err(InvalidCredentialError::MultipleCredentialSubjects);
+    };
+
+    let subject_properties = Value::Object(subject.properties.clone().into_iter().collect());
+    let subject: CredentialSubject =
+      serde_json::from_value(subject_properties).map_err(InvalidCredentialError::InvalidCredentialSubject)?;
+
+    if subject.type_.as_str() != CREDENTIAL_SUBJECT_TYPE {
+      return Err(InvalidCredentialError::InvalidSubjectType(subject.type_));
+    }
+
+    // An entry's status is read into a `usize`, which bounds how wide `statusSize` may be.
+    let entry_size = subject.entry_size();
+    if !(1..=MAXIMUM_ENTRY_SIZE).contains(&entry_size) {
+      return Err(InvalidCredentialError::InvalidStatusSize(entry_size));
+    }
+
+    // A "message" list names each of the values its entries can take.
+    if subject.status_purpose.contains(&StatusPurpose::Message) {
+      let size = subject.status_size.ok_or(InvalidCredentialError::MissingStatusSize)?;
+      // `size` is at most `MAXIMUM_ENTRY_SIZE`, so the shift cannot overflow.
+      let expected = 1usize << size;
+      if subject.status_messages.len() != expected {
+        return Err(InvalidCredentialError::InvalidMessageCount {
+          got: subject.status_messages.len(),
+          expected,
+        });
+      }
+    }
+
+    let decoded_list = decode_status_list(&subject.encoded_list)?;
+
+    Ok(Self {
+      credential,
+      subject,
+      decoded_list,
+    })
+  }
+}
+
+impl From<BitstringStatusListCredential> for CredentialV2 {
+  fn from(value: BitstringStatusListCredential) -> Self {
+    value.credential
+  }
+}
+
+/// The status of a single entry of a [`BitstringStatusListCredential`], as returned by
+/// [`BitstringStatusListCredential::entry`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct EntryStatus<'a> {
+  /// The value encoded by the entry's bits.
+  pub status: usize,
+  /// Whether the entry is unset, i.e. whether [`status`](Self::status) is 0.
+  ///
+  /// For a `revocation` list this means the referenced credential has not been revoked, for a `suspension`
+  /// list that it is not suspended, and so on.
+  pub valid: bool,
+  /// The purpose the status was read for, which describes what [`status`](Self::status) means.
+  pub purpose: StatusPurpose,
+  /// The message naming this status, set only for [`StatusPurpose::Message`] entries.
+  pub message: Option<&'a StatusMessage>,
+}
+
+/// A handle that sets the statuses of a [`BitstringStatusListCredential`]'s entries, obtained from
+/// [`BitstringStatusListCredential::update`].
+///
+/// Dropping it re-encodes the credential's `encodedList` from the updated bitstring, unless every
+/// [`set_entry`](Self::set_entry) call returned an error and the bitstring is therefore unchanged.
+#[derive(Debug)]
+pub struct StatusListMut<'a> {
+  credential: &'a mut BitstringStatusListCredential,
+  /// Whether a status was changed, i.e. whether `encodedList` has to be recomputed.
+  dirty: bool,
+}
+
+impl StatusListMut<'_> {
+  /// Sets the status of the entry referenced by `entry` to `value`.
+  ///
+  /// `value` is either a `bool`, for the single-bit entries of a `revocation`, `suspension` or `refresh`
+  /// list, or one of the credential's [`StatusMessage`]s, for the wider entries of a `message` list.
+  ///
+  /// ```
+  /// # use identity_core::common::Url;
+  /// # use identity_credential::credential::Issuer;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::credential::SetEntryError;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+  /// # let list_url = Url::parse("https://example.com/credentials/status/3")?;
+  /// # let mut status_list = BitstringStatusListCredentialBuilder::new()
+  /// #   .id(list_url.clone())
+  /// #   .issuer(Issuer::Url(Url::parse("did:example:12345")?))
+  /// #   .status_purposes(StatusPurpose::Revocation)
+  /// #   .build()?;
+  /// let entry = BitstringStatusListEntryBuilder::new()
+  ///   .credential(list_url)
+  ///   .index(94567)
+  ///   .status_purpose(StatusPurpose::Revocation)
+  ///   .build()?;
+  ///
+  /// status_list.update().set_entry(&entry, true)?;
+  /// assert!(!status_list.entry(94567, &StatusPurpose::Revocation)?.valid);
+  ///
+  /// // A revocation cannot be taken back.
+  /// let err = status_list.update().set_entry(&entry, false).unwrap_err();
+  /// assert!(matches!(err, SetEntryError::IrreversibleStatus));
+  /// # Ok::<(), Box<dyn std::error::Error>>(())
+  /// ```
+  ///
+  /// ## Errors
+  /// - [SetEntryError::CredentialMismatch] if `entry` references a different status list credential;
+  /// - [SetEntryError::InvalidPurpose] if this list does not serve the entry's purpose;
+  /// - [SetEntryError::EntrySizeMismatch] if the entry's statuses are not as wide as this credential's;
+  /// - [SetEntryError::InvalidMessage] if `value` is a message that either this credential or `entry` does not declare;
+  /// - [SetEntryError::StatusOutOfRange] if `value` does not fit in an entry of this credential;
+  /// - [SetEntryError::OutOfRange] if the entry's index is beyond the end of the list;
+  /// - [SetEntryError::IrreversibleStatus] if `value` would unset a `revocation` or `refresh` entry.
+  pub fn set_entry<'v>(
+    &mut self,
+    entry: &BitstringStatusListEntry,
+    value: impl Into<StatusValue<'v>>,
+  ) -> Result<&mut Self, SetEntryError> {
+    // Ensure entry actually references this credential. An unidentified credential cannot be
+    // referenced by an entry, so there is nothing to compare it against.
+    if let Some(id) = self.credential.id() {
+      if id != entry.status_list_credential() {
+        return Err(SetEntryError::CredentialMismatch {
+          expected: entry.status_list_credential().clone(),
+          got: id.clone(),
+        });
+      }
+    }
+    // Ensure entry's purpose is among the credential's purpose.
+    if !self.credential.subject.status_purpose.contains(entry.status_purpose()) {
+      return Err(SetEntryError::InvalidPurpose(entry.status_purpose().clone()));
+    }
+    // Ensure the entry describes statuses as wide as this credential's; otherwise its index would
+    // address a different range of bits than the issuer intended.
+    let entry_size = self.credential.entry_size();
+    if entry.status_size() != entry_size {
+      return Err(SetEntryError::EntrySizeMismatch {
+        expected: entry_size,
+        got: entry.status_size(),
+      });
+    }
+
+    let value = value.into();
+    if let StatusValue::Message(message) = value {
+      if !self.credential.subject.status_messages.contains(message) || !entry.status_message().contains(message) {
+        return Err(SetEntryError::InvalidMessage(message.clone()));
+      }
+    }
+
+    let new_status_value = usize::from(value);
+    // Storing a wider value than the entry would silently discard its most significant bits.
+    if new_status_value >= 1usize << entry_size {
+      return Err(SetEntryError::StatusOutOfRange {
+        status: new_status_value,
+        entry_size,
+      });
+    }
+
+    let range = self.credential.entry_range(entry.status_list_index())?;
+    let current_status_value = self.credential.decoded_list[range.clone()].load_be::<usize>();
+
+    // Ensure revoked and refreshed entries cannot be reverted.
+    if matches!(
+      entry.status_purpose(),
+      StatusPurpose::Refresh | StatusPurpose::Revocation
+    ) && current_status_value != 0
+      && new_status_value == 0
+    {
+      return Err(SetEntryError::IrreversibleStatus);
+    }
+
+    self.credential.decoded_list[range].store_be(new_status_value);
+    self.dirty = true;
+
+    Ok(self)
+  }
+}
+
+impl Drop for StatusListMut<'_> {
+  fn drop(&mut self) {
+    if self.dirty {
+      self.credential.sync_encoded_list();
+    }
+  }
+}
+
+/// Builder structure for [`BitstringStatusListCredential`]s.
+///
+/// [`issuer`](Self::issuer) and at least one purpose — set through
+/// [`status_purposes`](Self::status_purposes), or implied by [`status_messages`](Self::status_messages) —
+/// are required; everything else has a default.
+///
+/// ```
+/// # use identity_core::common::Url;
+/// # use identity_credential::credential::Issuer;
+/// use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+/// use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+///
+/// let status_list = BitstringStatusListCredentialBuilder::new()
+///   .id(Url::parse("https://example.com/credentials/status/3")?)
+///   .issuer(Issuer::Url(Url::parse("did:example:12345")?))
+///   .status_purposes(vec![StatusPurpose::Revocation, StatusPurpose::Suspension])
+///   .number_of_entries(200_000)
+///   .ttl(300_000)
+///   .build()?;
+///
+/// assert_eq!(
+///   status_list.purposes(),
+///   [StatusPurpose::Revocation, StatusPurpose::Suspension]
+/// );
+/// assert_eq!(status_list.entry_size(), 1);
+/// assert_eq!(status_list.ttl(), Some(300_000));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug)]
+pub struct BitstringStatusListCredentialBuilder {
+  inner_builder: CredentialBuilder,
+  subject: CredentialSubject,
+  number_of_entries: Option<usize>,
+}
+
+impl Default for BitstringStatusListCredentialBuilder {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl BitstringStatusListCredentialBuilder {
+  /// Returns a new [`BitstringStatusListCredentialBuilder`].
+  pub fn new() -> Self {
+    Self {
+      inner_builder: CredentialBuilder::new(Object::default()),
+      number_of_entries: None,
+      subject: CredentialSubject::default(),
+    }
+  }
+
+  /// Sets how many entries the status list can hold, i.e. the greatest `statusListIndex` an entry may
+  /// reference, plus one.
+  ///
+  /// Defaults to — and may not be less than — the 131072 entries the specification mandates as a minimum to
+  /// provide herd privacy.
+  pub fn number_of_entries(mut self, n: usize) -> Self {
+    self.number_of_entries = Some(n);
+    self
+  }
+
+  /// Sets the purposes this status list serves, i.e. what the bits of its entries encode.
+  pub fn status_purposes(mut self, purposes: impl Into<OneOrMany<StatusPurpose>>) -> Self {
+    self.subject.status_purpose = purposes.into();
+    self
+  }
+
+  /// Sets the messages naming the statuses this list's entries can take.
+  ///
+  /// Their number must be a power of two greater than 1, and determines how many bits each entry occupies:
+  /// `N` messages make for `log2(N)`-bit entries. Setting them also adds [`StatusPurpose::Message`] to the
+  /// list's purposes.
+  ///
+  /// ```
+  /// # use identity_core::common::Url;
+  /// # use identity_credential::credential::Issuer;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListCredentialBuilder;
+  /// # use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+  /// use identity_credential::revocation::bitstring_status_list_v1::StatusMessage;
+  /// use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
+  ///
+  /// let messages = vec![
+  ///   StatusMessage::new(0, "pending_review"),
+  ///   StatusMessage::new(1, "accepted"),
+  ///   StatusMessage::new(2, "rejected"),
+  ///   StatusMessage::new(3, "withdrawn"),
+  /// ];
+  /// # let list_url = Url::parse("https://example.com/credentials/status/8")?;
+  /// let mut status_list = BitstringStatusListCredentialBuilder::new()
+  ///   .id(list_url.clone())
+  ///   .issuer(Issuer::Url(Url::parse("did:example:12345")?))
+  ///   .status_messages(messages.clone())
+  ///   .build()?;
+  ///
+  /// // Four messages need two bits per entry, and imply the "message" purpose.
+  /// assert_eq!(status_list.entry_size(), 2);
+  /// assert_eq!(status_list.purposes(), [StatusPurpose::Message]);
+  ///
+  /// # let entry = BitstringStatusListEntryBuilder::new()
+  /// #   .credential(list_url)
+  /// #   .index(4711)
+  /// #   .status_purpose(StatusPurpose::Message)
+  /// #   .messages(messages.clone())
+  /// #   .build()?;
+  /// status_list.update().set_entry(&entry, &messages[2])?;
+  ///
+  /// let status = status_list.entry(4711, &StatusPurpose::Message)?;
+  /// assert_eq!(status.status, 2);
+  /// assert_eq!(status.message, Some(&messages[2]));
+  /// # Ok::<(), Box<dyn std::error::Error>>(())
+  /// ```
+  pub fn status_messages(mut self, messages: Vec<StatusMessage>) -> Self {
+    self.subject.status_messages = messages;
+    self
+  }
+
+  /// Sets `credentialSubject.ttl`: how long, in milliseconds, a cached copy of this credential may be used
+  /// before it should be fetched again.
+  pub fn ttl(mut self, ttl: u64) -> Self {
+    self.subject.ttl = Some(ttl);
+    self
+  }
+
+  /// Sets the credential's ID.
+  pub fn id(mut self, id: Url) -> Self {
+    self.inner_builder.id = Some(id);
+    self
+  }
+
+  /// Sets `validFrom`.
+  pub fn valid_from(mut self, time: Timestamp) -> Self {
+    self.inner_builder.issuance_date = Some(time);
+    self
+  }
+
+  /// Sets `validUntil`.
+  pub fn valid_until(mut self, time: Timestamp) -> Self {
+    self.inner_builder.expiration_date = Some(time);
+    self
+  }
+
+  /// Sets `issuer`.
+  pub fn issuer(mut self, issuer: Issuer) -> Self {
+    self.inner_builder.issuer = Some(issuer);
+    self
+  }
+
+  /// Adds a `@context` entry.
+  pub fn context(mut self, ctx: Context) -> Self {
+    self.inner_builder.context.push(ctx);
+    self
+  }
+
+  /// Adds a `type` entry.
+  pub fn add_type(mut self, type_: String) -> Self {
+    self.inner_builder.types.push(type_);
+    self
+  }
+
+  /// Adds a credential proof.
+  pub fn proof(mut self, proof: Proof) -> Self {
+    self.inner_builder.proof = Some(proof);
+    self
+  }
+
+  /// Consumes this builder, returning a [`BitstringStatusListCredential`] whose entries are all unset.
+  ///
+  /// ## Errors
+  /// - [BuilderError::TooFewEntries] if fewer entries than the specification's minimum were requested;
+  /// - [BuilderError::MissingPurpose] if no purpose was set;
+  /// - [BuilderError::InvalidNumberOfStatusMessages] if the number of status messages is not a power of two greater
+  ///   than 1;
+  /// - [BuilderError::InvalidStatusMessageValues] if the status messages do not name each of the values an entry can
+  ///   take exactly once;
+  /// - [BuilderError::CredentialBuilderError] if the underlying Verifiable Credential is incomplete, e.g. when no
+  ///   issuer was set.
+  pub fn build(mut self) -> Result<BitstringStatusListCredential, BuilderError> {
+    let number_of_entries = match self.number_of_entries {
+      Some(n) if n >= MINIMUM_NUMBER_OF_ENTRIES => n,
+      Some(n) => return Err(BuilderError::TooFewEntries(n)),
+      None => MINIMUM_NUMBER_OF_ENTRIES,
+    };
+    if !self.subject.status_messages.is_empty() || self.subject.status_purpose.contains(&StatusPurpose::Message) {
+      // `N` messages name the values of a `log2(N)`-bit status.
+      let number_of_messages = self.subject.status_messages.len();
+      if !(number_of_messages.is_power_of_two() && number_of_messages > 1) {
+        return Err(BuilderError::InvalidNumberOfStatusMessages);
+      }
+
+      // Every one of those values must be named exactly once: an unnamed value cannot be read back
+      // out, and one that does not fit in an entry cannot be stored in the first place.
+      let mut is_named = vec![false; number_of_messages];
+      for message in &self.subject.status_messages {
+        match is_named.get_mut(message.status) {
+          Some(is_named) if !*is_named => *is_named = true,
+          _ => return Err(BuilderError::InvalidStatusMessageValues(number_of_messages)),
+        }
+      }
+
+      self.subject.status_size = Some(number_of_messages.trailing_zeros() as usize);
+      if !self.subject.status_purpose.contains(&StatusPurpose::Message) {
+        self.subject.status_purpose.push(StatusPurpose::Message);
+      }
+    }
+
+    if self.subject.status_purpose.is_empty() {
+      return Err(BuilderError::MissingPurpose);
+    }
+
+    // Everything is valid, so the list can be allocated and encoded.
+    let status_list = bitvec![u8, Msb0; 0; number_of_entries * self.subject.entry_size()];
+    self.subject.encoded_list = encode_status_list(&status_list);
+
+    self.inner_builder.types.push(CREDENTIAL_TYPE.to_owned());
+    let Value::Object(subject_properties) =
+      serde_json::to_value(&self.subject).expect("a credential subject serializes to a JSON object")
+    else {
+      unreachable!("a credential subject serializes to a JSON object")
+    };
+    let subject = Subject::with_properties(subject_properties.into_iter().collect());
+    self.inner_builder.subject.push(subject);
+    let credential = self.inner_builder.build_v2()?;
+
+    Ok(BitstringStatusListCredential {
+      credential,
+      subject: self.subject,
+      decoded_list: status_list,
+    })
+  }
+}
+
+/// Error that may be returned by [`BitstringStatusListCredentialBuilder::build`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BuilderError {
+  /// Fewer entries than the specification's minimum were requested.
+  #[error("the minimum number of entries in the status list is {MINIMUM_NUMBER_OF_ENTRIES}, got {0}")]
+  TooFewEntries(usize),
+  /// No status purpose was set.
+  #[error("a status purpose must be specified")]
+  MissingPurpose,
+  /// Invalid number of status messages.
+  #[error("the number of status messages must be a power of two greater than 1")]
+  InvalidNumberOfStatusMessages,
+  /// The status messages do not name each of the values an entry can take exactly once.
+  #[error("status messages must name each of the {0} values an entry can take exactly once")]
+  InvalidStatusMessageValues(usize),
+  /// The underlying Verifiable Credential could not be built.
+  #[error(transparent)]
+  CredentialBuilderError(#[from] crate::Error),
+}
+
+/// Error that may be returned by [`StatusListMut::set_entry`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SetEntryError {
+  /// The entry references another status list credential.
+  #[error("expected credential with ID \"{expected}\", got \"{got}\"")]
+  CredentialMismatch {
+    /// The credential the entry references.
+    expected: Url,
+    /// The credential the entry was applied to.
+    got: Url,
+  },
+  /// The credential does not serve the entry's purpose.
+  #[error("credential does not contain purpose \"{}\"", .0.as_str())]
+  InvalidPurpose(StatusPurpose),
+  /// The entry's statuses are not as wide as the credential's.
+  #[error("expected an entry with a status size of {expected}, got {got}")]
+  EntrySizeMismatch {
+    /// The number of bits the credential's entries occupy.
+    expected: usize,
+    /// The number of bits the entry declares.
+    got: usize,
+  },
+  /// The status message is not one of those the credential and the entry declare.
+  #[error("credential does not contain status message \"{}\"", .0.message.as_str())]
+  InvalidMessage(StatusMessage),
+  /// The status does not fit in the credential's entries.
+  #[error("status {status:#x} does not fit in a {entry_size}-bit entry")]
+  StatusOutOfRange {
+    /// The status that was to be set.
+    status: usize,
+    /// The number of bits the credential's entries occupy.
+    entry_size: usize,
+  },
+  /// The entry's index lies outside the status list.
+  #[error(transparent)]
+  OutOfRange(#[from] IndexOutOfBounds),
+  /// An attempt was made to unset a `revocation` or `refresh` entry, which the specification defines as
+  /// irreversible.
+  #[error("status \"revocation\" and \"refresh\" cannot be reverted")]
+  IrreversibleStatus,
+}
+
+/// Error returned when a [`CredentialV2`] is not a valid [`BitstringStatusListCredential`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum InvalidCredentialError {
+  /// The credential's `type` does not include [`CREDENTIAL_TYPE`].
+  #[error("invalid credential type, \"BitstringStatusListCredential\" was expected")]
+  InvalidCredentialType,
+  /// The credential does not have exactly one `credentialSubject`.
+  #[error("expected exactly one credential subject")]
+  MultipleCredentialSubjects,
+  /// The credential subject's `type` is not [`CREDENTIAL_SUBJECT_TYPE`].
+  #[error("invalid credential subject's type: got \"{0}\", expected \"{CREDENTIAL_SUBJECT_TYPE}\"")]
+  InvalidSubjectType(String),
+  /// `statusSize` is zero, or wider than a status can be read into.
+  #[error("invalid \"statusSize\" {0}, expected an integer between 1 and {MAXIMUM_ENTRY_SIZE}")]
+  InvalidStatusSize(usize),
+  /// `statusSize` is missing from a credential that serves the `message` purpose.
+  #[error("property \"statusSize\" must be set when \"statusPurpose\" is \"message\"")]
+  MissingStatusSize,
+  /// The number of `statusMessages` does not match the one `statusSize` calls for, i.e. `2^statusSize`.
+  #[error("invalid number of \"statusMessages\": got {got}, expected {expected}")]
+  InvalidMessageCount {
+    /// The number of messages the credential declares.
+    got: usize,
+    /// The number of messages `statusSize` calls for.
+    expected: usize,
+  },
+  /// The credential subject is missing a mandatory property, or one of its properties has the wrong type.
+  #[error("failed to parse a valid \"BitstringStatusList\" credential subject")]
+  InvalidCredentialSubject(#[source] serde_json::Error),
+  /// `encodedList` is not a multibase string.
+  ///
+  /// The source error is deliberately opaque: it comes from a pre-1.0 crate whose type must not leak
+  /// into this crate's public API.
+  #[error("\"encodedList\" is not a valid multibase string")]
+  InvalidStatusListEncoding(#[source] Box<dyn std::error::Error + Send + Sync>),
+  /// `encodedList` is not a GZIP-compressed bitstring.
+  #[error("failed to decode \"encodedList\"")]
+  StatusListDecoding(#[source] std::io::Error),
+}
+
+/// Error that may be returned by [`BitstringStatusListCredential::entry`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EntryStatusError {
+  /// The requested index lies outside the status list.
+  #[error(transparent)]
+  OutOfRange(#[from] IndexOutOfBounds),
+  /// The credential does not serve the requested purpose.
+  #[error("credential does not contain purpose \"{}\"", .0.as_str())]
+  PurposeMismatch(StatusPurpose),
+  /// The entry's value is not one of the statuses the credential's `statusMessages` name.
+  #[error("status message \"{0:#x}\" does not exist")]
+  InvalidStatusMessage(usize),
+}
+
+/// Error returned when an entry's index lies outside the bounds of a status list.
+#[derive(Debug, thiserror::Error)]
+#[error("entry {0} is outside the list's bounds")]
+pub struct IndexOutOfBounds(usize);
+
+impl IndexOutOfBounds {
+  /// Returns the `statusListIndex` that lies outside the list.
+  pub fn index(&self) -> usize {
+    self.0
+  }
+}
+
+fn encode_status_list(status_list: &BitVec<u8, Msb0>) -> String {
+  use flate2::read::GzEncoder;
+  use multibase::Base;
+  use std::io::Read as _;
+
+  let mut encoder = GzEncoder::new(status_list.as_raw_slice(), flate2::Compression::best());
+  let mut compressed_bitstring = vec![];
+  encoder
+    .read_to_end(&mut compressed_bitstring)
+    .expect("compressing an in-memory buffer cannot fail");
+  multibase::encode(Base::Base64Url, compressed_bitstring)
+}
+
+fn decode_status_list(encoded_list: &str) -> Result<BitVec<u8, Msb0>, InvalidCredentialError> {
+  use std::io::Write as _;
+
+  let (_base, compressed_list) =
+    multibase::decode(encoded_list).map_err(|err| InvalidCredentialError::InvalidStatusListEncoding(Box::new(err)))?;
+
+  let mut decoder = flate2::write::GzDecoder::new(Vec::<u8>::new());
+  let bitstring = decoder
+    .write_all(&compressed_list)
+    .and_then(move |_| decoder.finish())
+    .map_err(InvalidCredentialError::StatusListDecoding)?;
+
+  Ok(BitVec::from_vec(bitstring))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::revocation::bitstring_status_list_v1::entry::BitstringStatusListEntryBuilder;
+
+  /// The example `BitstringStatusListCredential` taken verbatim from
+  /// [the specification](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential).
+  const SPEC_CREDENTIAL_JSON: &str = include_str!("./fixtures/credential-1.json");
+  const CREDENTIAL_URL: &str = "https://example.com/credentials/status/3";
+  const MESSAGE_CREDENTIAL_URL: &str = "https://example.com/credentials/status/8";
+
+  fn url(url: &str) -> Url {
+    Url::parse(url).unwrap()
+  }
+
+  fn issuer() -> Issuer {
+    Issuer::Url(url("did:example:12345"))
+  }
+
+  fn spec_credential() -> BitstringStatusListCredential {
+    serde_json::from_str(SPEC_CREDENTIAL_JSON).expect("the specification's example credential is valid")
+  }
+
+  /// Returns the specification's example credential, after applying `f` to its JSON representation.
+  fn patched_credential(f: impl FnOnce(&mut serde_json::Map<String, Value>)) -> CredentialV2 {
+    let mut credential: Value = serde_json::from_str(SPEC_CREDENTIAL_JSON).unwrap();
+    f(credential.as_object_mut().unwrap());
+    serde_json::from_value(credential).expect("a valid VC 2.0 credential")
+  }
+
+  /// Returns the specification's example credential, after applying `f` to its `credentialSubject`.
+  fn patched_subject(f: impl FnOnce(&mut serde_json::Map<String, Value>)) -> CredentialV2 {
+    patched_credential(|credential| {
+      let subject = credential
+        .get_mut("credentialSubject")
+        .and_then(Value::as_object_mut)
+        .unwrap();
+      f(subject)
+    })
+  }
+
+  fn credential_builder() -> BitstringStatusListCredentialBuilder {
+    BitstringStatusListCredentialBuilder::new()
+      .issuer(issuer())
+      .id(url(CREDENTIAL_URL))
+  }
+
+  fn entry(index: usize, purpose: StatusPurpose) -> BitstringStatusListEntry {
+    BitstringStatusListEntryBuilder::new()
+      .credential(url(CREDENTIAL_URL))
+      .index(index)
+      .status_purpose(purpose)
+      .build()
+      .unwrap()
+  }
+
+  fn status_messages() -> Vec<StatusMessage> {
+    vec![
+      StatusMessage::new(0, "pending_review"),
+      StatusMessage::new(1, "accepted"),
+      StatusMessage::new(2, "rejected"),
+      StatusMessage::new(3, "withdrawn"),
+    ]
+  }
+
+  fn decoded(encoded_list: &str) -> BitVec<u8, Msb0> {
+    decode_status_list(encoded_list).expect("a valid encoded status list")
+  }
+
+  #[test]
+  fn deserialization_of_the_spec_example_credential_works() {
+    let credential = spec_credential();
+
+    assert_eq!(credential.purposes(), [StatusPurpose::Revocation]);
+    assert_eq!(credential.entry_size(), 1);
+    assert_eq!(credential.ttl(), None);
+    assert_eq!(credential.id(), Some(&url(CREDENTIAL_URL)));
+    // The list is a 16KB bitstring in which nothing is revoked.
+    assert_eq!(credential.decoded_list.len(), MINIMUM_NUMBER_OF_ENTRIES);
+    assert_eq!(decoded(credential.encoded_list()).len(), MINIMUM_NUMBER_OF_ENTRIES);
+    assert!(credential.decoded_list.not_any());
+  }
+
+  #[test]
+  fn serialization_of_a_deserialized_credential_is_lossless() {
+    let expected: Value = serde_json::from_str(SPEC_CREDENTIAL_JSON).unwrap();
+    let credential = spec_credential();
+
+    assert_eq!(serde_json::to_value(&credential).unwrap(), expected);
+  }
+
+  #[test]
+  fn reading_the_status_of_an_unrevoked_entry_works() {
+    let credential = spec_credential();
+
+    let status = credential.entry(94567, &StatusPurpose::Revocation).unwrap();
+
+    assert_eq!(status.status, 0);
+    assert!(status.valid);
+    assert_eq!(status.purpose, StatusPurpose::Revocation);
+    assert_eq!(status.message, None);
+  }
+
+  #[test]
+  fn reading_an_entry_with_a_purpose_the_credential_does_not_serve_fails() {
+    let err = spec_credential().entry(94567, &StatusPurpose::Suspension).unwrap_err();
+
+    std::assert_matches!(err, EntryStatusError::PurposeMismatch(StatusPurpose::Suspension));
+  }
+
+  #[test]
+  fn reading_an_out_of_bounds_entry_fails() {
+    let err = spec_credential()
+      .entry(MINIMUM_NUMBER_OF_ENTRIES, &StatusPurpose::Revocation)
+      .unwrap_err();
+
+    std::assert_matches!(
+      err,
+      EntryStatusError::OutOfRange(IndexOutOfBounds(MINIMUM_NUMBER_OF_ENTRIES))
+    );
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_without_the_expected_type_fails() {
+    let credential = patched_credential(|credential| {
+      credential.insert("type".to_owned(), serde_json::json!(["VerifiableCredential"]));
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::InvalidCredentialType);
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_with_multiple_subjects_fails() {
+    let credential = patched_credential(|credential| {
+      let subject = credential.get("credentialSubject").cloned().unwrap();
+      credential.insert("credentialSubject".to_owned(), serde_json::json!([subject, subject]));
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::MultipleCredentialSubjects);
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_with_an_invalid_subject_type_fails() {
+    let credential = patched_subject(|subject| {
+      subject.insert("type".to_owned(), "StatusList2021".into());
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::InvalidSubjectType(ty) if ty == "StatusList2021");
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_without_an_encoded_list_fails() {
+    let credential = patched_subject(|subject| {
+      subject.remove("encodedList");
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::InvalidCredentialSubject(_));
+  }
+
+  #[test]
+  fn deserialization_of_a_message_credential_without_status_size_fails() {
+    let credential = patched_subject(|subject| {
+      subject.insert("statusPurpose".to_owned(), "message".into());
+      subject.insert(
+        "statusMessages".to_owned(),
+        serde_json::to_value(status_messages()).unwrap(),
+      );
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::MissingStatusSize);
+  }
+
+  #[test]
+  fn deserialization_of_a_message_credential_with_a_wrong_number_of_messages_fails() {
+    let credential = patched_subject(|subject| {
+      let mut messages = status_messages();
+      messages.pop();
+      subject.insert("statusPurpose".to_owned(), "message".into());
+      subject.insert("statusSize".to_owned(), 2.into());
+      subject.insert("statusMessages".to_owned(), serde_json::to_value(messages).unwrap());
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::InvalidMessageCount { got: 3, expected: 4 });
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_with_a_non_multibase_encoded_list_fails() {
+    let credential = patched_subject(|subject| {
+      subject.insert("encodedList".to_owned(), "not a multibase string".into());
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::InvalidStatusListEncoding(_));
+  }
+
+  #[test]
+  fn deserialization_of_a_credential_with_a_non_compressed_encoded_list_fails() {
+    let credential = patched_subject(|subject| {
+      let uncompressed = multibase::encode(multibase::Base::Base64Url, b"not a gzip stream");
+      subject.insert("encodedList".to_owned(), uncompressed.into());
+    });
+
+    let err = BitstringStatusListCredential::try_from(credential).unwrap_err();
+
+    std::assert_matches!(err, InvalidCredentialError::StatusListDecoding(_));
+  }
+
+  #[test]
+  fn building_a_credential_works() {
+    let credential = credential_builder()
+      .status_purposes(StatusPurpose::Revocation)
+      .ttl(300_000)
+      .valid_from(Timestamp::parse("2021-04-05T14:27:40Z").unwrap())
+      .valid_until(Timestamp::parse("2031-04-05T14:27:40Z").unwrap())
+      .build()
+      .unwrap();
+
+    assert_eq!(credential.purposes(), [StatusPurpose::Revocation]);
+    assert_eq!(credential.entry_size(), 1);
+    assert_eq!(credential.ttl(), Some(300_000));
+    assert_eq!(credential.decoded_list.len(), MINIMUM_NUMBER_OF_ENTRIES);
+    assert!(credential.decoded_list.not_any());
+
+    let json = serde_json::to_value(&credential).unwrap();
+    assert_eq!(
+      json["type"],
+      serde_json::json!(["VerifiableCredential", CREDENTIAL_TYPE])
+    );
+    assert_eq!(json["credentialSubject"]["type"], CREDENTIAL_SUBJECT_TYPE);
+    assert_eq!(json["credentialSubject"]["statusPurpose"], "revocation");
+    assert_eq!(json["credentialSubject"]["ttl"], 300_000);
+    assert_eq!(json["validUntil"], "2031-04-05T14:27:40Z");
+  }
+
+  #[test]
+  fn an_empty_built_status_list_matches_the_spec_example() {
+    let credential = credential_builder()
+      .status_purposes(StatusPurpose::Revocation)
+      .build()
+      .unwrap();
+
+    // The compressed representations may differ, the encoded bitstrings must not.
+    assert_eq!(
+      decoded(credential.encoded_list()),
+      decoded(spec_credential().encoded_list())
+    );
+  }
+
+  #[test]
+  fn a_built_credential_can_be_serialized_and_deserialized() {
+    let credential = credential_builder()
+      .status_purposes(vec![StatusPurpose::Revocation, StatusPurpose::Suspension])
+      .build()
+      .unwrap();
+
+    let json = serde_json::to_string(&credential).unwrap();
+    let deserialized: BitstringStatusListCredential = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.purposes(), credential.purposes());
+    assert_eq!(deserialized.encoded_list(), credential.encoded_list());
+    assert_eq!(deserialized.decoded_list, credential.decoded_list);
+  }
+
+  #[test]
+  fn building_a_credential_with_status_messages_works() {
+    let messages = status_messages();
+    let credential = credential_builder().status_messages(messages.clone()).build().unwrap();
+
+    // A credential carrying status messages implicitly serves the "message" purpose,
+    // and its status size is derived from the number of messages.
+    assert_eq!(credential.purposes(), [StatusPurpose::Message]);
+    assert_eq!(credential.entry_size(), 2);
+    assert_eq!(credential.decoded_list.len(), MINIMUM_NUMBER_OF_ENTRIES * 2);
+  }
+
+  #[test]
+  fn building_a_credential_with_too_few_entries_fails() {
+    let err = credential_builder()
+      .status_purposes(StatusPurpose::Revocation)
+      .number_of_entries(MINIMUM_NUMBER_OF_ENTRIES - 1)
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::TooFewEntries(131_071));
+  }
+
+  #[test]
+  fn building_a_credential_without_a_purpose_fails() {
+    let err = credential_builder().build().unwrap_err();
+
+    std::assert_matches!(err, BuilderError::MissingPurpose);
+  }
+
+  #[test]
+  fn building_a_credential_with_an_invalid_number_of_status_messages_fails() {
+    let mut messages = status_messages();
+    messages.pop();
+
+    let err = credential_builder().status_messages(messages).build().unwrap_err();
+
+    std::assert_matches!(err, BuilderError::InvalidNumberOfStatusMessages);
+  }
+
+  #[test]
+  fn building_a_credential_without_an_issuer_fails() {
+    let err = BitstringStatusListCredentialBuilder::new()
+      .status_purposes(StatusPurpose::Revocation)
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::CredentialBuilderError(crate::Error::MissingIssuer));
+  }
+
+  #[test]
+  fn revoking_an_entry_works() {
+    let mut credential = spec_credential();
+    let entry = entry(94567, StatusPurpose::Revocation);
+    let encoded_list_before = credential.encoded_list().to_owned();
+
+    credential.update().set_entry(&entry, true).unwrap();
+
+    let status = credential.entry(94567, &StatusPurpose::Revocation).unwrap();
+    assert_eq!(status.status, 1);
+    assert!(!status.valid);
+
+    // Only the referenced entry has been set, at the position mandated by the specification:
+    // index 0 is the left-most (most significant) bit of the first byte, which is exactly how a
+    // `Msb0`-ordered bitstring is indexed.
+    assert_eq!(credential.decoded_list.count_ones(), 1);
+    assert!(credential.decoded_list[94567]);
+
+    // The credential's `encodedList` has been kept in sync with the updated bitstring.
+    assert_ne!(credential.encoded_list(), encoded_list_before);
+    let json = serde_json::to_value(&credential).unwrap();
+    assert_eq!(json["credentialSubject"]["encodedList"], credential.encoded_list());
+  }
+
+  #[test]
+  fn a_revoked_entry_cannot_be_unrevoked() {
+    let mut credential = spec_credential();
+    let entry = entry(94567, StatusPurpose::Revocation);
+    credential.update().set_entry(&entry, true).unwrap();
+
+    let err = credential.update().set_entry(&entry, false).unwrap_err();
+
+    std::assert_matches!(err, SetEntryError::IrreversibleStatus);
+    assert!(!credential.entry(94567, &StatusPurpose::Revocation).unwrap().valid);
+  }
+
+  #[test]
+  fn a_suspended_entry_can_be_unsuspended() {
+    let mut credential = credential_builder()
+      .status_purposes(StatusPurpose::Suspension)
+      .build()
+      .unwrap();
+    let entry = entry(23452, StatusPurpose::Suspension);
+
+    credential.update().set_entry(&entry, true).unwrap();
+    assert!(!credential.entry(23452, &StatusPurpose::Suspension).unwrap().valid);
+
+    credential.update().set_entry(&entry, false).unwrap();
+    assert!(credential.entry(23452, &StatusPurpose::Suspension).unwrap().valid);
+    assert!(credential.decoded_list.not_any());
+  }
+
+  #[test]
+  fn setting_an_entry_of_another_credential_fails() {
+    let mut credential = spec_credential();
+    let entry = BitstringStatusListEntryBuilder::new()
+      .credential(url("https://example.com/credentials/status/4"))
+      .index(94567)
+      .status_purpose(StatusPurpose::Revocation)
+      .build()
+      .unwrap();
+
+    let err = credential.update().set_entry(&entry, true).unwrap_err();
+
+    std::assert_matches!(err, SetEntryError::CredentialMismatch { .. });
+  }
+
+  #[test]
+  fn setting_an_entry_with_a_purpose_the_credential_does_not_serve_fails() {
+    let mut credential = spec_credential();
+    let entry = entry(94567, StatusPurpose::Suspension);
+
+    let err = credential.update().set_entry(&entry, true).unwrap_err();
+
+    std::assert_matches!(err, SetEntryError::InvalidPurpose(StatusPurpose::Suspension));
+  }
+
+  #[test]
+  fn setting_an_out_of_bounds_entry_fails() {
+    let mut credential = spec_credential();
+    let entry = entry(MINIMUM_NUMBER_OF_ENTRIES, StatusPurpose::Revocation);
+
+    let err = credential.update().set_entry(&entry, true).unwrap_err();
+
+    std::assert_matches!(
+      err,
+      SetEntryError::OutOfRange(IndexOutOfBounds(MINIMUM_NUMBER_OF_ENTRIES))
+    );
+  }
+
+  #[test]
+  fn setting_a_status_message_works() {
+    let messages = status_messages();
+    let mut credential = BitstringStatusListCredentialBuilder::new()
+      .issuer(issuer())
+      .id(url(MESSAGE_CREDENTIAL_URL))
+      .status_messages(messages.clone())
+      .build()
+      .unwrap();
+    let entry = BitstringStatusListEntryBuilder::new()
+      .credential(url(MESSAGE_CREDENTIAL_URL))
+      .index(4711)
+      .status_purpose(StatusPurpose::Message)
+      .messages(messages.clone())
+      .build()
+      .unwrap();
+
+    credential.update().set_entry(&entry, &messages[2]).unwrap();
+
+    let status = credential.entry(4711, &StatusPurpose::Message).unwrap();
+    assert_eq!(status.status, 2);
+    assert_eq!(status.message, Some(&messages[2]));
+    // A 2-bit wide status of `0x2` occupies the two bits starting at index 4711 * 2.
+    assert!(credential.decoded_list[4711 * 2]);
+    assert!(!credential.decoded_list[4711 * 2 + 1]);
+  }
+
+  #[test]
+  fn setting_a_status_message_the_credential_does_not_declare_fails() {
+    let messages = status_messages();
+    let unknown_message = StatusMessage::new(2, "unknown");
+    let mut credential = BitstringStatusListCredentialBuilder::new()
+      .issuer(issuer())
+      .id(url(MESSAGE_CREDENTIAL_URL))
+      .status_messages(messages.clone())
+      .build()
+      .unwrap();
+    let entry = BitstringStatusListEntryBuilder::new()
+      .credential(url(MESSAGE_CREDENTIAL_URL))
+      .index(4711)
+      .status_purpose(StatusPurpose::Message)
+      .messages(messages)
+      .build()
+      .unwrap();
+
+    let err = credential.update().set_entry(&entry, &unknown_message).unwrap_err();
+
+    std::assert_matches!(err, SetEntryError::InvalidMessage(_));
+  }
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/credential.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/credential.rs
@@ -655,8 +655,8 @@ impl BitstringStatusListCredentialBuilder {
   }
 
   /// Sets `issuer`.
-  pub fn issuer(mut self, issuer: Issuer) -> Self {
-    self.inner_builder.issuer = Some(issuer);
+  pub fn issuer(mut self, issuer: impl Into<Issuer>) -> Self {
+    self.inner_builder.issuer = Some(issuer.into());
     self
   }
 

--- a/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 use serde::Serializer;
 use serde_json::Value;
 
-use crate::credential::Status;
+use crate::credential::StatusV2;
 use crate::revocation::bitstring_status_list_v1::StatusMessage;
 use crate::revocation::bitstring_status_list_v1::StatusPurpose;
 
@@ -319,20 +319,17 @@ impl<'de> Deserialize<'de> for BitstringStatusListEntry {
   }
 }
 
-impl TryFrom<&Status> for BitstringStatusListEntry {
+impl TryFrom<StatusV2> for BitstringStatusListEntry {
   type Error = serde_json::Error;
-  fn try_from(status: &Status) -> Result<Self, Self::Error> {
+  fn try_from(status: StatusV2) -> Result<Self, Self::Error> {
     serde_json::to_value(status).and_then(serde_json::from_value)
   }
 }
 
-impl From<BitstringStatusListEntry> for Status {
-  fn from(entry: BitstringStatusListEntry) -> Self {
-    // A `Status` must be identified, whereas an entry's `id` is optional; the status list
-    // credential it points to identifies it well enough in that case. A `Status` converted to an
-    // entry and back therefore gains an `id`.
-    let id = entry.id.clone().unwrap_or_else(|| entry.status_list_credential.clone());
-    let type_ = entry.type_.to_owned();
+impl From<BitstringStatusListEntry> for StatusV2 {
+  fn from(mut entry: BitstringStatusListEntry) -> Self {
+    let id = entry.id.take();
+    let type_ = OneOrMany::One(entry.type_.to_owned());
 
     let Value::Object(mut properties) =
       serde_json::to_value(entry).expect("a status list entry serializes to a JSON object")
@@ -343,7 +340,11 @@ impl From<BitstringStatusListEntry> for Status {
     properties.remove("id");
     properties.remove("type");
 
-    Status::new_with_properties(id, type_, properties.into_iter().collect())
+    StatusV2 {
+      id,
+      type_,
+      properties: properties.into_iter().collect(),
+    }
   }
 }
 
@@ -370,29 +371,11 @@ mod tests {
     for entry_json in [VALID_ENTRY_JSON_1, VALID_ENTRY_JSON_2, VALID_ENTRY_JSON_3] {
       let entry: BitstringStatusListEntry = serde_json::from_str(entry_json).unwrap();
 
-      let status = Status::from(entry.clone());
-      assert_eq!(status.type_, ENTRY_TYPE);
-      assert_eq!(Some(&status.id), entry.id());
-      assert_eq!(BitstringStatusListEntry::try_from(&status).unwrap(), entry);
+      let status = StatusV2::from(entry.clone());
+      assert_eq!(status.type_.first().unwrap(), ENTRY_TYPE);
+      assert_eq!(status.id.as_ref(), entry.id());
+      assert_eq!(BitstringStatusListEntry::try_from(status).unwrap(), entry);
     }
-  }
-
-  #[test]
-  fn an_entry_without_an_id_borrows_the_status_list_url_when_converted_to_a_status() {
-    let status_list = Url::parse("https://example.com/status/1").unwrap();
-    let entry = BitstringStatusListEntryBuilder::new()
-      .credential(status_list.clone())
-      .index(0)
-      .status_purpose(StatusPurpose::Revocation)
-      .build()
-      .unwrap();
-    assert_eq!(entry.id(), None);
-    // An id-less entry must not serialize `"id": null`, which is what would reach `Status`.
-    assert!(serde_json::to_value(&entry).unwrap().get("id").is_none());
-
-    let status = Status::from(entry);
-
-    assert_eq!(status.id, status_list);
   }
 
   #[test]

--- a/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
@@ -1,0 +1,522 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types for the [`BitstringStatusListEntry`], the `credentialStatus` object embedded in a
+//! [Verifiable Credential](crate::credential::Credential) to reference an entry inside a
+//! [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/).
+//!
+//! An entry points at a specific bit (or group of bits) within a hosted status list credential
+//! through its [`statusListCredential`](BitstringStatusListEntry::status_list_credential) URL and
+//! [`statusListIndex`](BitstringStatusListEntry::status_list_index). The
+//! [`statusPurpose`](BitstringStatusListEntry::status_purpose) describes what that bit encodes
+//! (e.g. revocation or suspension).
+//!
+//! Entries are created with the [`BitstringStatusListEntryBuilder`]:
+//!
+//! ```
+//! use identity_core::common::Url;
+//! use identity_credential::revocation::bitstring_status_list_v1::entry::BitstringStatusListEntryBuilder;
+//! use identity_credential::revocation::bitstring_status_list_v1::entry::StatusPurpose;
+//!
+//! let entry = BitstringStatusListEntryBuilder::new()
+//!   .status_purpose(StatusPurpose::Revocation)
+//!   .index(94567)
+//!   .credential(Url::parse("https://example.com/credentials/status/3")?)
+//!   .build()?;
+//!
+//! assert_eq!(entry.status_purpose(), &StatusPurpose::Revocation);
+//! assert_eq!(entry.status_list_index(), 94567);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use identity_core::common::Object;
+use identity_core::common::OneOrMany;
+use identity_core::common::Url;
+use serde::de::Error as _;
+use serde::de::Unexpected;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde_json::Value;
+
+/// Value of the `type` property, as defined in [Bitstring Status List Entry](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry).
+pub const TYPE: &str = "BitstringStatusListEntry";
+static DEFAULT_STATUS_MESSAGE: LazyLock<[StatusMessage; 2]> =
+  LazyLock::new(|| [StatusMessage::new(0, "unset"), StatusMessage::new(1, "set")]);
+
+/// A single entry in a [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/).
+/// Used as a value of the `credentialStatus` property in a [Verifiable Credential](crate::credential::Credential).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct BitstringStatusListEntry {
+  id: Option<Url>,
+  #[serde(rename = "type")]
+  type_: &'static str,
+  status_purpose: StatusPurpose,
+  #[serde(serialize_with = "serialize_number_as_string")]
+  status_list_index: usize,
+  status_list_credential: Url,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  status_size: Option<usize>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  status_message: Vec<StatusMessage>,
+  #[serde(skip_serializing_if = "OneOrMany::is_empty")]
+  status_reference: OneOrMany<Url>,
+}
+
+impl BitstringStatusListEntry {
+  /// Returns the optional `id` of the entry.
+  pub fn id(&self) -> Option<&Url> {
+    self.id.as_ref()
+  }
+
+  /// Returns the `type` of the entry, which is always equal to `BitstringStatusListEntry`.
+  pub fn type_(&self) -> &'static str {
+    self.type_
+  }
+
+  /// Returns the `statusPurpose` of the entry, which describes what the bit encodes (e.g. revocation or suspension).
+  pub fn status_purpose(&self) -> &StatusPurpose {
+    &self.status_purpose
+  }
+
+  /// Returns the `statusListIndex` of the entry, which is the index of the status contained within the status list
+  /// credential.
+  pub fn status_list_index(&self) -> usize {
+    self.status_list_index
+  }
+
+  /// Returns the `statusListCredential` of the entry, which is the URL of the status list credential.
+  pub fn status_list_credential(&self) -> &Url {
+    &self.status_list_credential
+  }
+
+  /// Returns the `statusMessage` of the entry, which is an optional array of status messages associated with the status
+  /// list entry. When no entries are present, the status list entry is considered to be a simple "set" / "unset"
+  /// status.
+  pub fn status_message(&self) -> &[StatusMessage] {
+    if self.status_message.is_empty() {
+      DEFAULT_STATUS_MESSAGE.as_slice()
+    } else {
+      &self.status_message
+    }
+  }
+
+  /// Returns the size of this entry's status in bits.
+  pub fn status_size(&self) -> usize {
+    self.status_message().len().trailing_zeros() as usize
+  }
+
+  /// Returns the `statusReference` of the entry, which is an optional array of URLs referencing additional information
+  /// about the status.
+  pub fn status_reference(&self) -> &[Url] {
+    self.status_reference.as_slice()
+  }
+}
+
+/// The purpose of the status list entry, which describes what the bit encodes (e.g. revocation or suspension).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase", untagged)]
+pub enum StatusPurpose {
+  /// Used to signal that an updated verifiable credential is available via the credential's refresh service feature.
+  /// This status does not invalidate the verifiable credential and is not reversible
+  Refresh,
+  /// Used to cancel the validity of a verifiable credential. This status is not reversible.
+  Revocation,
+  /// Used to temporarily prevent the acceptance of a verifiable credential. This status is reversible.
+  Suspension,
+  /// Used to convey an arbitrary message related to the status of the verifiable credential.
+  Message,
+  /// Arbitrary status purpose.
+  Custom(String),
+}
+
+impl StatusPurpose {
+  /// Returns the string representation of the status purpose.
+  pub fn as_str(&self) -> &str {
+    match self {
+      StatusPurpose::Refresh => "refresh",
+      StatusPurpose::Revocation => "revocation",
+      StatusPurpose::Suspension => "suspension",
+      StatusPurpose::Message => "message",
+      StatusPurpose::Custom(custom) => custom.as_str(),
+    }
+  }
+}
+
+impl<'a, T> From<T> for StatusPurpose
+where
+  T: Into<Cow<'a, str>>,
+{
+  fn from(value: T) -> Self {
+    let value = value.into();
+    match value.as_ref() {
+      "refresh" => StatusPurpose::Refresh,
+      "revocation" => StatusPurpose::Revocation,
+      "suspension" => StatusPurpose::Suspension,
+      "message" => StatusPurpose::Message,
+      _ => StatusPurpose::Custom(value.to_string()),
+    }
+  }
+}
+
+/// A status message associated with a status list entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct StatusMessage {
+  /// Status ID.
+  #[serde(serialize_with = "serialize_status_message")]
+  pub status: usize,
+  /// Status debug information.
+  pub message: String,
+  /// Arbitrary addicitional properties.
+  #[serde(flatten)]
+  pub properties: Object,
+}
+
+impl StatusMessage {
+  /// Returns a new [StatusMessage] with the provided `status` and `message`.
+  pub fn new(status: usize, message: impl Into<String>) -> Self {
+    Self {
+      status,
+      message: message.into(),
+      properties: Object::new(),
+    }
+  }
+}
+
+/// Builder structure for [BitstringStatusListEntry].
+#[derive(Debug, Default)]
+pub struct BitstringStatusListEntryBuilder {
+  id: Option<Url>,
+  status_purpose: Option<StatusPurpose>,
+  status_list_index: Option<usize>,
+  status_list_credential: Option<Url>,
+  status_message: Vec<StatusMessage>,
+  status_reference: OneOrMany<Url>,
+}
+
+impl BitstringStatusListEntryBuilder {
+  /// Returns a new [BitstringStatusListEntryBuilder].
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Sets the optional ID for this entry.
+  pub fn id(mut self, id: Url) -> Self {
+    self.id = Some(id);
+    self
+  }
+
+  /// Sets the purpose for this entry.
+  pub fn status_purpose(mut self, status_purpose: impl Into<StatusPurpose>) -> Self {
+    self.status_purpose = Some(status_purpose.into());
+    self
+  }
+
+  /// Sets the index of this entry.
+  pub fn index(mut self, status_list_index: usize) -> Self {
+    self.status_list_index = Some(status_list_index);
+    self
+  }
+
+  /// Sets the status list credentials of this entry.
+  pub fn credential(mut self, status_list_credential: Url) -> Self {
+    self.status_list_credential = Some(status_list_credential);
+    self
+  }
+
+  /// Sets custom messages of this entry.
+  pub fn messages(mut self, messages: impl IntoIterator<Item = StatusMessage>) -> Self {
+    self.status_message = messages.into_iter().collect();
+    self
+  }
+
+  /// Sets the custom messages of this entry.
+  /// The messages will be assigned a stutus based on their position, starting from `0x0` to `0x<N - 1>`
+  /// where N is the length of the given list.
+  pub fn ordered_messages(mut self, messages: impl IntoIterator<Item = String>) -> Self {
+    self.status_message = messages
+      .into_iter()
+      .enumerate()
+      .map(|(status, message)| StatusMessage::new(status, message))
+      .collect();
+    self
+  }
+
+  /// Sets the references of this entry.
+  pub fn references(mut self, references: impl Into<OneOrMany<Url>>) -> Self {
+    self.status_reference = references.into();
+    self
+  }
+
+  /// Consumes this builder returning a [BitstringStatusListEntry].
+  /// ## Errors
+  /// - [BuilderError::MissingField] is returned when any of the mandatory properties has not being supplied;
+  /// - [BuilderError::InvalidStatusMessagesCount] is returned if an invalid number of messages have been set. Messages
+  ///   must be a power of 2 greater than 1.
+  pub fn build(self) -> Result<BitstringStatusListEntry, BuilderError> {
+    let status_size = match self.status_message.len() {
+      0 | 2 => None,
+      len if len > 1 && len.is_power_of_two() => Some(len.trailing_zeros() as usize),
+      invalid_len => return Err(BuilderError::InvalidStatusMessagesCount(invalid_len)),
+    };
+    let status_purpose = self.status_purpose.ok_or(BuilderError::MissingField("statusPurpose"))?;
+    let status_list_index = self
+      .status_list_index
+      .ok_or(BuilderError::MissingField("statusListIndex"))?;
+    let status_list_credential = self
+      .status_list_credential
+      .ok_or(BuilderError::MissingField("statusListCredential"))?;
+
+    Ok(BitstringStatusListEntry {
+      id: self.id,
+      type_: TYPE,
+      status_purpose,
+      status_list_index,
+      status_list_credential,
+      status_size,
+      status_message: self.status_message,
+      status_reference: self.status_reference,
+    })
+  }
+}
+
+/// Error that may be returned by [BitstringStatusListEntryBuilder::build].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BuilderError {
+  /// A mandatory field was not supplied.
+  #[error("missing required field `{0}`")]
+  MissingField(&'static str),
+  /// Invalid number of messages.
+  #[error("invalid number of status messages, expected a power of two, got {0}")]
+  InvalidStatusMessagesCount(usize),
+}
+
+impl<'de> Deserialize<'de> for StatusMessage {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let mut properties = Object::deserialize(deserializer)?;
+    let Value::String(status) = properties
+      .remove("status")
+      .ok_or_else(|| D::Error::missing_field("status"))?
+    else {
+      return Err(D::Error::invalid_type(
+        Unexpected::Other("non-string"),
+        &"hex-encoded integer",
+      ));
+    };
+    let status = usize::from_str_radix(status.trim_start_matches("0x"), 16)
+      .map_err(|_| D::Error::invalid_value(Unexpected::Str(&status), &"hex-encoded integer"))?;
+
+    let message = properties
+      .remove("message")
+      .ok_or_else(|| D::Error::missing_field("message"))?
+      .as_str()
+      .ok_or_else(|| D::Error::invalid_type(Unexpected::Other("non-string"), &"string"))?
+      .to_owned();
+
+    Ok(Self {
+      status,
+      message,
+      properties,
+    })
+  }
+}
+
+fn serialize_status_message<S>(status: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_str(&format!("{status:#x}"))
+}
+
+fn serialize_number_as_string<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_str(&value.to_string())
+}
+
+impl<'de> Deserialize<'de> for BitstringStatusListEntry {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Helper<'a> {
+      id: Option<Url>,
+      #[serde(rename = "type")]
+      type_: &'a str,
+      status_purpose: StatusPurpose,
+      status_list_index: &'a str,
+      status_list_credential: Url,
+      status_size: Option<usize>,
+      #[serde(default)]
+      status_message: Vec<StatusMessage>,
+      #[serde(default)]
+      status_reference: OneOrMany<Url>,
+    }
+
+    let helper = Helper::deserialize(deserializer)?;
+
+    // Property type must be equal to "BitstringStatusListEntry".
+    if helper.type_ != TYPE {
+      return Err(serde::de::Error::invalid_value(Unexpected::Str(helper.type_), &TYPE));
+    }
+
+    // When statusSize is present, it must be a positive integer and the number of status messages must be equal to
+    // 2^statusSize.
+    if let Some(size) = helper.status_size {
+      if size == 0 {
+        return Err(serde::de::Error::invalid_value(
+          Unexpected::Unsigned(size as u64),
+          &"positive integer",
+        ));
+      }
+
+      let expected_message_count = 2_usize.pow(size as u32);
+      if helper.status_message.len() != expected_message_count {
+        return Err(serde::de::Error::invalid_length(
+          helper.status_message.len(),
+          &format!("{} status messages for statusSize {}", expected_message_count, size).as_str(),
+        ));
+      }
+    } else {
+      // When statusSize is not present, the number of status messages must be equal to 2 or 0 (implicit "set" /
+      // "unset").
+      if !(helper.status_message.is_empty() || helper.status_message.len() == 2) {
+        return Err(serde::de::Error::invalid_length(
+          helper.status_message.len(),
+          &"2 status messages for statusSize 1",
+        ));
+      }
+    }
+
+    let status_list_index = helper.status_list_index.parse().map_err(|_| {
+      serde::de::Error::invalid_value(
+        Unexpected::Str(helper.status_list_index),
+        &"base 10 integer, expressed as a string",
+      )
+    })?;
+
+    Ok(Self {
+      id: helper.id,
+      type_: TYPE,
+      status_purpose: helper.status_purpose,
+      status_list_index,
+      status_list_credential: helper.status_list_credential,
+      status_size: helper.status_size,
+      status_message: helper.status_message,
+      status_reference: helper.status_reference,
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const VALID_ENTRY_JSON_1: &str = include_str!("./fixtures/entry-1.json");
+  const VALID_ENTRY_JSON_2: &str = include_str!("./fixtures/entry-2.json");
+  const VALID_ENTRY_JSON_3: &str = include_str!("./fixtures/entry-3.json");
+
+  #[test]
+  fn serialization_and_deserialization_of_valid_status_list_entry_works() {
+    for entry_json in [VALID_ENTRY_JSON_1, VALID_ENTRY_JSON_2, VALID_ENTRY_JSON_3] {
+      let entry: BitstringStatusListEntry = serde_json::from_str(entry_json).unwrap();
+      let serialized_entry = serde_json::to_string(&entry).unwrap();
+      let deserialized_entry: BitstringStatusListEntry = serde_json::from_str(&serialized_entry).unwrap();
+      assert_eq!(entry, deserialized_entry);
+    }
+  }
+
+  #[test]
+  fn deserialization_of_entry_with_invalid_type_fails() {
+    let err =
+      serde_json::from_str::<BitstringStatusListEntry>(include_str!("./fixtures/entry-invalid-type.json")).unwrap_err();
+    assert_eq!(
+      err.to_string(),
+      "invalid value: string \"InvalidType\", expected BitstringStatusListEntry"
+    );
+  }
+
+  #[test]
+  fn deserialization_of_entry_with_wrong_number_of_status_messages_fails() {
+    let err = serde_json::from_str::<BitstringStatusListEntry>(include_str!(
+      "./fixtures/entry-invalid-status-message-count.json"
+    ))
+    .unwrap_err();
+    assert_eq!(
+      err.to_string(),
+      "invalid length 3, expected 4 status messages for statusSize 2"
+    );
+  }
+
+  #[test]
+  fn building_valid_entry_works() {
+    let entry = BitstringStatusListEntryBuilder::new()
+      .credential(Url::parse("https://example.com/status/1").unwrap())
+      .index(0)
+      .status_purpose("revocation")
+      .build()
+      .unwrap();
+
+    assert_eq!(entry.status_purpose(), &StatusPurpose::Revocation);
+    assert_eq!(entry.status_message(), DEFAULT_STATUS_MESSAGE.as_slice());
+    assert_eq!(entry.status_size(), 1)
+  }
+
+  #[test]
+  fn building_without_purpose_fails() {
+    let err = BitstringStatusListEntryBuilder::new()
+      .credential(Url::parse("https://example.com/status/1").unwrap())
+      .index(0)
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::MissingField("statusPurpose"));
+  }
+
+  #[test]
+  fn building_without_index_fails() {
+    let err = BitstringStatusListEntryBuilder::new()
+      .credential(Url::parse("https://example.com/status/1").unwrap())
+      .status_purpose(StatusPurpose::Revocation)
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::MissingField("statusListIndex"));
+  }
+
+  #[test]
+  fn building_without_credential_fails() {
+    let err = BitstringStatusListEntryBuilder::new()
+      .index(0)
+      .status_purpose(StatusPurpose::Revocation)
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::MissingField("statusListCredential"));
+  }
+
+  #[test]
+  fn building_with_wrong_message_count_fails() {
+    let err = BitstringStatusListEntryBuilder::new()
+      .credential(Url::parse("https://example.com/status/1").unwrap())
+      .status_purpose(StatusPurpose::Revocation)
+      .index(0)
+      .ordered_messages(["revoked".to_owned()])
+      .build()
+      .unwrap_err();
+
+    std::assert_matches!(err, BuilderError::InvalidStatusMessagesCount(1));
+  }
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/entry.rs
@@ -15,8 +15,8 @@
 //!
 //! ```
 //! use identity_core::common::Url;
-//! use identity_credential::revocation::bitstring_status_list_v1::entry::BitstringStatusListEntryBuilder;
-//! use identity_credential::revocation::bitstring_status_list_v1::entry::StatusPurpose;
+//! use identity_credential::revocation::bitstring_status_list_v1::BitstringStatusListEntryBuilder;
+//! use identity_credential::revocation::bitstring_status_list_v1::StatusPurpose;
 //!
 //! let entry = BitstringStatusListEntryBuilder::new()
 //!   .status_purpose(StatusPurpose::Revocation)
@@ -29,13 +29,10 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use std::borrow::Cow;
 use std::sync::LazyLock;
 
-use identity_core::common::Object;
 use identity_core::common::OneOrMany;
 use identity_core::common::Url;
-use serde::de::Error as _;
 use serde::de::Unexpected;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -43,9 +40,16 @@ use serde::Serialize;
 use serde::Serializer;
 use serde_json::Value;
 
+use crate::credential::Status;
+use crate::revocation::bitstring_status_list_v1::StatusMessage;
+use crate::revocation::bitstring_status_list_v1::StatusPurpose;
+
 /// Value of the `type` property, as defined in [Bitstring Status List Entry](https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry).
-pub const TYPE: &str = "BitstringStatusListEntry";
-static DEFAULT_STATUS_MESSAGE: LazyLock<[StatusMessage; 2]> =
+pub const ENTRY_TYPE: &str = "BitstringStatusListEntry";
+/// The greatest `statusSize` an entry may declare: a status is read into a `usize`, and the number
+/// of values it can take — `2^statusSize` — must itself be representable.
+const MAXIMUM_STATUS_SIZE: usize = usize::BITS as usize - 1;
+static DEFAULT_STATUS_MESSAGES: LazyLock<[StatusMessage; 2]> =
   LazyLock::new(|| [StatusMessage::new(0, "unset"), StatusMessage::new(1, "set")]);
 
 /// A single entry in a [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/).
@@ -53,6 +57,7 @@ static DEFAULT_STATUS_MESSAGE: LazyLock<[StatusMessage; 2]> =
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct BitstringStatusListEntry {
+  #[serde(skip_serializing_if = "Option::is_none")]
   id: Option<Url>,
   #[serde(rename = "type")]
   type_: &'static str,
@@ -100,7 +105,7 @@ impl BitstringStatusListEntry {
   /// status.
   pub fn status_message(&self) -> &[StatusMessage] {
     if self.status_message.is_empty() {
-      DEFAULT_STATUS_MESSAGE.as_slice()
+      DEFAULT_STATUS_MESSAGES.as_slice()
     } else {
       &self.status_message
     }
@@ -115,76 +120,6 @@ impl BitstringStatusListEntry {
   /// about the status.
   pub fn status_reference(&self) -> &[Url] {
     self.status_reference.as_slice()
-  }
-}
-
-/// The purpose of the status list entry, which describes what the bit encodes (e.g. revocation or suspension).
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "lowercase", untagged)]
-pub enum StatusPurpose {
-  /// Used to signal that an updated verifiable credential is available via the credential's refresh service feature.
-  /// This status does not invalidate the verifiable credential and is not reversible
-  Refresh,
-  /// Used to cancel the validity of a verifiable credential. This status is not reversible.
-  Revocation,
-  /// Used to temporarily prevent the acceptance of a verifiable credential. This status is reversible.
-  Suspension,
-  /// Used to convey an arbitrary message related to the status of the verifiable credential.
-  Message,
-  /// Arbitrary status purpose.
-  Custom(String),
-}
-
-impl StatusPurpose {
-  /// Returns the string representation of the status purpose.
-  pub fn as_str(&self) -> &str {
-    match self {
-      StatusPurpose::Refresh => "refresh",
-      StatusPurpose::Revocation => "revocation",
-      StatusPurpose::Suspension => "suspension",
-      StatusPurpose::Message => "message",
-      StatusPurpose::Custom(custom) => custom.as_str(),
-    }
-  }
-}
-
-impl<'a, T> From<T> for StatusPurpose
-where
-  T: Into<Cow<'a, str>>,
-{
-  fn from(value: T) -> Self {
-    let value = value.into();
-    match value.as_ref() {
-      "refresh" => StatusPurpose::Refresh,
-      "revocation" => StatusPurpose::Revocation,
-      "suspension" => StatusPurpose::Suspension,
-      "message" => StatusPurpose::Message,
-      _ => StatusPurpose::Custom(value.to_string()),
-    }
-  }
-}
-
-/// A status message associated with a status list entry.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-pub struct StatusMessage {
-  /// Status ID.
-  #[serde(serialize_with = "serialize_status_message")]
-  pub status: usize,
-  /// Status debug information.
-  pub message: String,
-  /// Arbitrary addicitional properties.
-  #[serde(flatten)]
-  pub properties: Object,
-}
-
-impl StatusMessage {
-  /// Returns a new [StatusMessage] with the provided `status` and `message`.
-  pub fn new(status: usize, message: impl Into<String>) -> Self {
-    Self {
-      status,
-      message: message.into(),
-      properties: Object::new(),
-    }
   }
 }
 
@@ -236,7 +171,7 @@ impl BitstringStatusListEntryBuilder {
   }
 
   /// Sets the custom messages of this entry.
-  /// The messages will be assigned a stutus based on their position, starting from `0x0` to `0x<N - 1>`
+  /// The messages will be assigned a status based on their position, starting from `0x0` to `0x<N - 1>`
   /// where N is the length of the given list.
   pub fn ordered_messages(mut self, messages: impl IntoIterator<Item = String>) -> Self {
     self.status_message = messages
@@ -260,7 +195,10 @@ impl BitstringStatusListEntryBuilder {
   ///   must be a power of 2 greater than 1.
   pub fn build(self) -> Result<BitstringStatusListEntry, BuilderError> {
     let status_size = match self.status_message.len() {
+      // `statusSize` defaults to 1 and the specification does not require it to accompany
+      // `statusMessage`, so a "set" / "unset" entry can leave it out altogether.
       0 | 2 => None,
+      // A single message would make for a zero-bit status.
       len if len > 1 && len.is_power_of_two() => Some(len.trailing_zeros() as usize),
       invalid_len => return Err(BuilderError::InvalidStatusMessagesCount(invalid_len)),
     };
@@ -274,7 +212,7 @@ impl BitstringStatusListEntryBuilder {
 
     Ok(BitstringStatusListEntry {
       id: self.id,
-      type_: TYPE,
+      type_: ENTRY_TYPE,
       status_purpose,
       status_list_index,
       status_list_credential,
@@ -293,48 +231,8 @@ pub enum BuilderError {
   #[error("missing required field `{0}`")]
   MissingField(&'static str),
   /// Invalid number of messages.
-  #[error("invalid number of status messages, expected a power of two, got {0}")]
+  #[error("invalid number of status messages, expected a power of two greater than 1, got {0}")]
   InvalidStatusMessagesCount(usize),
-}
-
-impl<'de> Deserialize<'de> for StatusMessage {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: Deserializer<'de>,
-  {
-    let mut properties = Object::deserialize(deserializer)?;
-    let Value::String(status) = properties
-      .remove("status")
-      .ok_or_else(|| D::Error::missing_field("status"))?
-    else {
-      return Err(D::Error::invalid_type(
-        Unexpected::Other("non-string"),
-        &"hex-encoded integer",
-      ));
-    };
-    let status = usize::from_str_radix(status.trim_start_matches("0x"), 16)
-      .map_err(|_| D::Error::invalid_value(Unexpected::Str(&status), &"hex-encoded integer"))?;
-
-    let message = properties
-      .remove("message")
-      .ok_or_else(|| D::Error::missing_field("message"))?
-      .as_str()
-      .ok_or_else(|| D::Error::invalid_type(Unexpected::Other("non-string"), &"string"))?
-      .to_owned();
-
-    Ok(Self {
-      status,
-      message,
-      properties,
-    })
-  }
-}
-
-fn serialize_status_message<S>(status: &usize, serializer: S) -> Result<S::Ok, S::Error>
-where
-  S: Serializer,
-{
-  serializer.serialize_str(&format!("{status:#x}"))
 }
 
 fn serialize_number_as_string<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
@@ -351,12 +249,12 @@ impl<'de> Deserialize<'de> for BitstringStatusListEntry {
   {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
-    struct Helper<'a> {
+    struct Helper {
       id: Option<Url>,
       #[serde(rename = "type")]
-      type_: &'a str,
+      type_: String,
       status_purpose: StatusPurpose,
-      status_list_index: &'a str,
+      status_list_index: String,
       status_list_credential: Url,
       status_size: Option<usize>,
       #[serde(default)]
@@ -368,48 +266,49 @@ impl<'de> Deserialize<'de> for BitstringStatusListEntry {
     let helper = Helper::deserialize(deserializer)?;
 
     // Property type must be equal to "BitstringStatusListEntry".
-    if helper.type_ != TYPE {
-      return Err(serde::de::Error::invalid_value(Unexpected::Str(helper.type_), &TYPE));
+    if helper.type_ != ENTRY_TYPE {
+      return Err(serde::de::Error::invalid_value(
+        Unexpected::Str(&helper.type_),
+        &ENTRY_TYPE,
+      ));
     }
 
-    // When statusSize is present, it must be a positive integer and the number of status messages must be equal to
-    // 2^statusSize.
-    if let Some(size) = helper.status_size {
-      if size == 0 {
-        return Err(serde::de::Error::invalid_value(
-          Unexpected::Unsigned(size as u64),
-          &"positive integer",
-        ));
-      }
+    // `statusSize` counts the bits of a status, so it must be a positive integer; the upper bound is
+    // ours, as a status is read into a `usize`. It defaults to 1 when absent.
+    let status_size = helper.status_size.unwrap_or(1);
+    if !(1..=MAXIMUM_STATUS_SIZE).contains(&status_size) {
+      return Err(serde::de::Error::invalid_value(
+        Unexpected::Unsigned(status_size as u64),
+        &format!("integer between 1 and {MAXIMUM_STATUS_SIZE}").as_str(),
+      ));
+    }
 
-      let expected_message_count = 2_usize.pow(size as u32);
-      if helper.status_message.len() != expected_message_count {
-        return Err(serde::de::Error::invalid_length(
-          helper.status_message.len(),
-          &format!("{} status messages for statusSize {}", expected_message_count, size).as_str(),
-        ));
-      }
-    } else {
-      // When statusSize is not present, the number of status messages must be equal to 2 or 0 (implicit "set" /
-      // "unset").
-      if !(helper.status_message.is_empty() || helper.status_message.len() == 2) {
-        return Err(serde::de::Error::invalid_length(
-          helper.status_message.len(),
-          &"2 status messages for statusSize 1",
-        ));
-      }
+    // `statusMessage` must name each of the `2^statusSize` values a status can take. It may be left
+    // out entirely for a single-bit status, which is then an implicit "set" / "unset".
+    let expected_message_count = 1usize << status_size;
+    let message_count = helper.status_message.len();
+    let omitted = message_count == 0 && status_size == 1;
+    if message_count != expected_message_count && !omitted {
+      return Err(serde::de::Error::invalid_length(
+        message_count,
+        &format!(
+          "{}{expected_message_count} status messages for statusSize {status_size}",
+          if status_size == 1 { "0 or " } else { "" },
+        )
+        .as_str(),
+      ));
     }
 
     let status_list_index = helper.status_list_index.parse().map_err(|_| {
       serde::de::Error::invalid_value(
-        Unexpected::Str(helper.status_list_index),
+        Unexpected::Str(&helper.status_list_index),
         &"base 10 integer, expressed as a string",
       )
     })?;
 
     Ok(Self {
       id: helper.id,
-      type_: TYPE,
+      type_: ENTRY_TYPE,
       status_purpose: helper.status_purpose,
       status_list_index,
       status_list_credential: helper.status_list_credential,
@@ -417,6 +316,34 @@ impl<'de> Deserialize<'de> for BitstringStatusListEntry {
       status_message: helper.status_message,
       status_reference: helper.status_reference,
     })
+  }
+}
+
+impl TryFrom<&Status> for BitstringStatusListEntry {
+  type Error = serde_json::Error;
+  fn try_from(status: &Status) -> Result<Self, Self::Error> {
+    serde_json::to_value(status).and_then(serde_json::from_value)
+  }
+}
+
+impl From<BitstringStatusListEntry> for Status {
+  fn from(entry: BitstringStatusListEntry) -> Self {
+    // A `Status` must be identified, whereas an entry's `id` is optional; the status list
+    // credential it points to identifies it well enough in that case. A `Status` converted to an
+    // entry and back therefore gains an `id`.
+    let id = entry.id.clone().unwrap_or_else(|| entry.status_list_credential.clone());
+    let type_ = entry.type_.to_owned();
+
+    let Value::Object(mut properties) =
+      serde_json::to_value(entry).expect("a status list entry serializes to a JSON object")
+    else {
+      unreachable!("a status list entry serializes to a JSON object")
+    };
+    // `id` and `type` are named fields of `Status` rather than part of its properties.
+    properties.remove("id");
+    properties.remove("type");
+
+    Status::new_with_properties(id, type_, properties.into_iter().collect())
   }
 }
 
@@ -436,6 +363,36 @@ mod tests {
       let deserialized_entry: BitstringStatusListEntry = serde_json::from_str(&serialized_entry).unwrap();
       assert_eq!(entry, deserialized_entry);
     }
+  }
+
+  #[test]
+  fn conversion_to_and_from_a_credential_status_works() {
+    for entry_json in [VALID_ENTRY_JSON_1, VALID_ENTRY_JSON_2, VALID_ENTRY_JSON_3] {
+      let entry: BitstringStatusListEntry = serde_json::from_str(entry_json).unwrap();
+
+      let status = Status::from(entry.clone());
+      assert_eq!(status.type_, ENTRY_TYPE);
+      assert_eq!(Some(&status.id), entry.id());
+      assert_eq!(BitstringStatusListEntry::try_from(&status).unwrap(), entry);
+    }
+  }
+
+  #[test]
+  fn an_entry_without_an_id_borrows_the_status_list_url_when_converted_to_a_status() {
+    let status_list = Url::parse("https://example.com/status/1").unwrap();
+    let entry = BitstringStatusListEntryBuilder::new()
+      .credential(status_list.clone())
+      .index(0)
+      .status_purpose(StatusPurpose::Revocation)
+      .build()
+      .unwrap();
+    assert_eq!(entry.id(), None);
+    // An id-less entry must not serialize `"id": null`, which is what would reach `Status`.
+    assert!(serde_json::to_value(&entry).unwrap().get("id").is_none());
+
+    let status = Status::from(entry);
+
+    assert_eq!(status.id, status_list);
   }
 
   #[test]
@@ -470,7 +427,7 @@ mod tests {
       .unwrap();
 
     assert_eq!(entry.status_purpose(), &StatusPurpose::Revocation);
-    assert_eq!(entry.status_message(), DEFAULT_STATUS_MESSAGE.as_slice());
+    assert_eq!(entry.status_message(), DEFAULT_STATUS_MESSAGES.as_slice());
     assert_eq!(entry.status_size(), 1)
   }
 

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/credential-1.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/credential-1.json
@@ -1,0 +1,15 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2"
+    ],
+    "id": "https://example.com/credentials/status/3",
+    "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+    "issuer": "did:example:12345",
+    "validFrom": "2021-04-05T14:27:40Z",
+    "credentialSubject": {
+        "id": "https://example.com/status/3#list",
+        "type": "BitstringStatusList",
+        "statusPurpose": "revocation",
+        "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+    }
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-1.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-1.json
@@ -1,0 +1,7 @@
+{
+    "id": "https://example.com/credentials/status/3#94567",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "https://example.com/credentials/status/3"
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-2.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-2.json
@@ -1,0 +1,7 @@
+{
+    "id": "https://example.com/credentials/status/4#23452",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "suspension",
+    "statusListIndex": "23452",
+    "statusListCredential": "https://example.com/credentials/status/4"
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-3.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-3.json
@@ -1,0 +1,15 @@
+{
+    "id": "https://example.com/credentials/status/8#492847",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "message",
+    "statusListIndex": "492847",
+    "statusSize": 2,
+    "statusListCredential": "https://example.com/credentials/status/8",
+    "statusMessage": [
+        {"status":"0x0", "message":"pending_review"},
+        {"status":"0x1", "message":"accepted"},
+        {"status":"0x2", "message":"rejected"},
+        {"status":"0x3", "message":"undefined"}
+    ],
+    "statusReference": "https://example.org/status-dictionary/"
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-invalid-status-message-count.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-invalid-status-message-count.json
@@ -1,0 +1,14 @@
+{
+    "id": "https://example.com/credentials/status/8#492847",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "message",
+    "statusListIndex": "492847",
+    "statusSize": 2,
+    "statusListCredential": "https://example.com/credentials/status/8",
+    "statusMessage": [
+        {"status":"0x0", "message":"pending_review"},
+        {"status":"0x1", "message":"accepted"},
+        {"status":"0x2", "message":"rejected"}
+    ],
+    "statusReference": "https://example.org/status-dictionary/"
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-invalid-type.json
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/fixtures/entry-invalid-type.json
@@ -1,0 +1,7 @@
+{
+    "id": "https://example.com/credentials/status/3#94567",
+    "type": "InvalidType",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "https://example.com/credentials/status/3"
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
@@ -4,6 +4,9 @@
 //! Implementation of the [Bitstring Status List v1](https://www.w3.org/TR/vc-bitstring-status-list/) revocation method.
 
 use std::borrow::Cow;
+use std::convert::Infallible;
+use std::fmt::Display;
+use std::str::FromStr;
 
 use identity_core::common::Object;
 use serde::de::Error as _;
@@ -51,6 +54,25 @@ impl StatusPurpose {
       StatusPurpose::Message => "message",
       StatusPurpose::Custom(custom) => custom.as_str(),
     }
+  }
+}
+
+impl Display for StatusPurpose {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.as_str())
+  }
+}
+
+impl FromStr for StatusPurpose {
+  type Err = Infallible;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    Ok(match s {
+      "refresh" => Self::Refresh,
+      "revocation" => Self::Revocation,
+      "suspension" => Self::Suspension,
+      "message" => Self::Message,
+      s => Self::Custom(s.to_owned()),
+    })
   }
 }
 

--- a/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
@@ -1,6 +1,163 @@
 // Copyright 2020-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! implementations of [Bitstring Status list v1](https://www.w3.org/TR/vc-bitstring-status-list/) revocation method.
+//! Implementation of the [Bitstring Status List v1](https://www.w3.org/TR/vc-bitstring-status-list/) revocation method.
 
+use std::borrow::Cow;
+
+use identity_core::common::Object;
+use serde::de::Error as _;
+use serde::de::Unexpected;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+pub mod credential;
 pub mod entry;
+
+pub use credential::BitstringStatusListCredential;
+pub use credential::BitstringStatusListCredentialBuilder;
+pub use credential::EntryStatus;
+pub use credential::StatusListMut;
+pub use credential::CREDENTIAL_TYPE;
+pub use entry::BitstringStatusListEntry;
+pub use entry::BitstringStatusListEntryBuilder;
+pub use entry::ENTRY_TYPE;
+
+/// The purpose of the status list entry, which describes what the bit encodes (e.g. revocation or suspension).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StatusPurpose {
+  /// Used to signal that an updated verifiable credential is available via the credential's refresh service feature.
+  /// This status does not invalidate the verifiable credential and is not reversible
+  Refresh,
+  /// Used to cancel the validity of a verifiable credential. This status is not reversible.
+  Revocation,
+  /// Used to temporarily prevent the acceptance of a verifiable credential. This status is reversible.
+  Suspension,
+  /// Used to convey an arbitrary message related to the status of the verifiable credential.
+  Message,
+  /// Arbitrary status purpose.
+  Custom(String),
+}
+
+impl StatusPurpose {
+  /// Returns the string representation of the status purpose.
+  pub fn as_str(&self) -> &str {
+    match self {
+      StatusPurpose::Refresh => "refresh",
+      StatusPurpose::Revocation => "revocation",
+      StatusPurpose::Suspension => "suspension",
+      StatusPurpose::Message => "message",
+      StatusPurpose::Custom(custom) => custom.as_str(),
+    }
+  }
+}
+
+impl Serialize for StatusPurpose {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(self.as_str())
+  }
+}
+
+impl<'de> Deserialize<'de> for StatusPurpose {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    String::deserialize(deserializer).map(StatusPurpose::from)
+  }
+}
+
+impl<'a, T> From<T> for StatusPurpose
+where
+  T: Into<Cow<'a, str>>,
+{
+  fn from(value: T) -> Self {
+    let value = value.into();
+    match value.as_ref() {
+      "refresh" => StatusPurpose::Refresh,
+      "revocation" => StatusPurpose::Revocation,
+      "suspension" => StatusPurpose::Suspension,
+      "message" => StatusPurpose::Message,
+      _ => StatusPurpose::Custom(value.to_string()),
+    }
+  }
+}
+
+/// A status message associated with a status list entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct StatusMessage {
+  /// Status ID.
+  #[serde(
+    serialize_with = "serialize_status_message",
+    deserialize_with = "deserialize_status_message"
+  )]
+  pub status: usize,
+  /// Status debug information.
+  pub message: String,
+  /// Arbitrary additional properties.
+  #[serde(flatten)]
+  pub properties: Object,
+}
+
+impl StatusMessage {
+  /// Returns a new [StatusMessage] with the provided `status` and `message`.
+  pub fn new(status: usize, message: impl Into<String>) -> Self {
+    Self {
+      status,
+      message: message.into(),
+      properties: Object::new(),
+    }
+  }
+}
+
+fn serialize_status_message<S>(status: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  serializer.serialize_str(&format!("{status:#x}"))
+}
+
+fn deserialize_status_message<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+  D: Deserializer<'de>,
+{
+  let s = String::deserialize(deserializer)?;
+  s.strip_prefix("0x")
+    .and_then(|digits| usize::from_str_radix(digits, 16).ok())
+    .ok_or_else(|| D::Error::invalid_value(Unexpected::Str(&s), &"hex literal"))
+}
+
+/// The value a status list entry can be set to, through [`StatusListMut::set_entry`].
+#[derive(Debug, Clone)]
+pub enum StatusValue<'a> {
+  /// The value of a single-bit entry, i.e. of a `revocation`, `suspension` or `refresh` entry.
+  Flag(bool),
+  /// One of the statuses named by a `message` entry's [`StatusMessage`]s.
+  Message(&'a StatusMessage),
+}
+
+impl From<bool> for StatusValue<'_> {
+  fn from(value: bool) -> Self {
+    Self::Flag(value)
+  }
+}
+
+impl<'a> From<&'a StatusMessage> for StatusValue<'a> {
+  fn from(value: &'a StatusMessage) -> Self {
+    Self::Message(value)
+  }
+}
+
+impl<'a> From<StatusValue<'a>> for usize {
+  fn from(value: StatusValue<'a>) -> Self {
+    match value {
+      StatusValue::Flag(b) => b as usize,
+      StatusValue::Message(message) => message.status,
+    }
+  }
+}

--- a/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
+++ b/identity_credential/src/revocation/bitstring_status_list_v1/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2020-2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! implementations of [Bitstring Status list v1](https://www.w3.org/TR/vc-bitstring-status-list/) revocation method.
+
+pub mod entry;

--- a/identity_credential/src/revocation/mod.rs
+++ b/identity_credential/src/revocation/mod.rs
@@ -9,6 +9,8 @@ mod revocation_bitmap_2022;
 #[cfg(feature = "status-list-2021")]
 pub mod status_list_2021;
 
+pub mod bitstring_status_list_v1;
+
 #[cfg(feature = "jpt-bbs-plus")]
 pub mod validity_timeframe_2024;
 

--- a/identity_credential/src/revocation/mod.rs
+++ b/identity_credential/src/revocation/mod.rs
@@ -8,7 +8,7 @@ mod error;
 mod revocation_bitmap_2022;
 #[cfg(feature = "status-list-2021")]
 pub mod status_list_2021;
-
+#[cfg(feature = "bitstring-status-list")]
 pub mod bitstring_status_list_v1;
 
 #[cfg(feature = "jpt-bbs-plus")]

--- a/identity_credential/src/revocation/mod.rs
+++ b/identity_credential/src/revocation/mod.rs
@@ -4,12 +4,12 @@
 //! Contains the implementations for all the credential revocation methods that can be used with IOTA's Identity
 //! framework.
 
+#[cfg(feature = "bitstring-status-list")]
+pub mod bitstring_status_list_v1;
 mod error;
 mod revocation_bitmap_2022;
 #[cfg(feature = "status-list-2021")]
 pub mod status_list_2021;
-#[cfg(feature = "bitstring-status-list")]
-pub mod bitstring_status_list_v1;
 
 #[cfg(feature = "jpt-bbs-plus")]
 pub mod validity_timeframe_2024;

--- a/identity_credential/src/revocation/status_list_2021/entry.rs
+++ b/identity_credential/src/revocation/status_list_2021/entry.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::credential::Status;
+use crate::credential::StatusV2;
 
 use super::credential::StatusPurpose;
 
@@ -49,7 +50,7 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusList2021Entry {
-  id: Url,
+  id: Option<Url>,
   #[serde(rename = "type", deserialize_with = "deserialize_status_entry_type")]
   type_: String,
   status_purpose: StatusPurpose,
@@ -61,15 +62,34 @@ pub struct StatusList2021Entry {
   status_list_credential: Url,
 }
 
-impl TryFrom<&Status> for StatusList2021Entry {
-  type Error = serde_json::Error;
-  fn try_from(status: &Status) -> Result<Self, Self::Error> {
-    let json_status = serde_json::to_value(status)?;
-    serde_json::from_value(json_status)
+macro_rules! impl_try_from_status {
+  ($status_ty: ident) => {
+    impl TryFrom<$status_ty> for StatusList2021Entry {
+      type Error = serde_json::Error;
+      fn try_from(value: $status_ty) -> Result<Self, Self::Error> {
+        let json_status = serde_json::to_value(value)?;
+        serde_json::from_value(json_status)
+      }
+    }
+  };
+}
+
+impl_try_from_status!(Status);
+impl_try_from_status!(StatusV2);
+
+impl From<StatusList2021Entry> for Status {
+  fn from(mut entry: StatusList2021Entry) -> Self {
+    if entry.id.is_none() {
+      let mut id = entry.status_list_credential.clone();
+      id.set_fragment(None);
+      entry.id = Some(id);
+    }
+    let json_status = serde_json::to_value(entry).unwrap(); // Safety: shouldn't go out of memory
+    serde_json::from_value(json_status).unwrap() // Safety: `StatusList2021Entry` is a credential status
   }
 }
 
-impl From<StatusList2021Entry> for Status {
+impl From<StatusList2021Entry> for StatusV2 {
   fn from(entry: StatusList2021Entry) -> Self {
     let json_status = serde_json::to_value(entry).unwrap(); // Safety: shouldn't go out of memory
     serde_json::from_value(json_status).unwrap() // Safety: `StatusList2021Entry` is a credential status
@@ -79,12 +99,6 @@ impl From<StatusList2021Entry> for Status {
 impl StatusList2021Entry {
   /// Creates a new [`StatusList2021Entry`].
   pub fn new(status_list: Url, purpose: StatusPurpose, index: usize, id: Option<Url>) -> Self {
-    let id = id.unwrap_or_else(|| {
-      let mut id = status_list.clone();
-      id.set_fragment(None);
-      id
-    });
-
     Self {
       id,
       type_: CREDENTIAL_STATUS_TYPE.to_owned(),
@@ -95,8 +109,8 @@ impl StatusList2021Entry {
   }
 
   /// Returns this `credentialStatus`'s `id`.
-  pub const fn id(&self) -> &Url {
-    &self.id
+  pub fn id(&self) -> Option<&Url> {
+    self.id.as_ref()
   }
 
   /// Returns the purpose of this entry.

--- a/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator.rs
+++ b/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator.rs
@@ -25,6 +25,7 @@ use crate::credential::CredentialJwtClaims;
 use crate::credential::CredentialT;
 use crate::credential::Jwt;
 use crate::credential::JwtVcV2;
+use crate::credential::StatusV2;
 use crate::validator::DecodedJwtCredentialV2;
 use crate::validator::FailFast;
 
@@ -83,7 +84,7 @@ impl<V: JwsVerifier> JwtCredentialValidator<V> {
         validation_errors: [err].into(),
       })?;
 
-    Self::validate_decoded_credential::<CoreDocument, T>(
+    Self::validate_decoded_credential::<CoreDocument, T, Credential<T>>(
       &credential_token.credential,
       std::slice::from_ref(issuer.as_ref()),
       options,
@@ -209,8 +210,8 @@ impl<V: JwsVerifier> JwtCredentialValidator<V> {
   // This method takes a slice of issuer's instead of a single issuer in order to better accommodate presentation
   // validation. It also validates the relationship between a holder and the credential subjects when
   // `relationship_criterion` is Some.
-  pub(crate) fn validate_decoded_credential<DOC, T>(
-    credential: &dyn CredentialT<Properties = T>,
+  pub(crate) fn validate_decoded_credential<DOC, T, C>(
+    credential: &C,
     issuers: &[DOC],
     options: &JwtCredentialValidationOptions,
     fail_fast: FailFast,
@@ -218,6 +219,7 @@ impl<V: JwsVerifier> JwtCredentialValidator<V> {
   where
     T: Clone + serde::Serialize + serde::de::DeserializeOwned,
     DOC: AsRef<CoreDocument>,
+    C: CredentialT<Properties = T, Status: Clone + Into<StatusV2>>,
   {
     // Run all single concern Credential validations in turn and fail immediately if `fail_fast` is true.
 

--- a/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator_utils.rs
+++ b/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator_utils.rs
@@ -15,8 +15,15 @@ use crate::credential::Credential;
 use crate::credential::CredentialJwtClaims;
 use crate::credential::CredentialT;
 use crate::credential::CredentialV2;
+#[cfg(feature = "revocation-bitmap")]
+use crate::credential::RevocationBitmapStatus;
+use crate::credential::StatusT;
+#[cfg(feature = "revocation-bitmap")]
+use crate::credential::StatusV2;
 #[cfg(feature = "status-list-2021")]
 use crate::revocation::status_list_2021::StatusList2021Credential;
+#[cfg(feature = "status-list-2021")]
+use crate::revocation::status_list_2021::StatusList2021Entry;
 use crate::validator::SubjectHolderRelationship;
 
 /// Utility functions for verifying JWT credentials.
@@ -31,7 +38,7 @@ impl JwtCredentialValidatorUtils {
   ///
   /// # Warning
   /// This does not validate against the credential's schema nor the structure of the subject claims.
-  pub fn check_structure<T>(credential: &dyn CredentialT<Properties = T>) -> ValidationUnitResult {
+  pub fn check_structure<T>(credential: &impl CredentialT<Properties = T>) -> ValidationUnitResult {
     // Ensure the base context is present and in the correct location
     match credential.context().get(0) {
       Some(context) if context == credential.base_context() => {}
@@ -68,7 +75,7 @@ impl JwtCredentialValidatorUtils {
 
   /// Validate that the [`Credential`] expires after the specified [`Timestamp`].
   pub fn check_expires_on_or_after<T>(
-    credential: &dyn CredentialT<Properties = T>,
+    credential: &impl CredentialT<Properties = T>,
     timestamp: Timestamp,
   ) -> ValidationUnitResult {
     match credential.valid_until() {
@@ -79,7 +86,7 @@ impl JwtCredentialValidatorUtils {
 
   /// Validate that the [`Credential`] is issued on or before the specified [`Timestamp`].
   pub fn check_issued_on_or_before<T>(
-    credential: &dyn CredentialT<Properties = T>,
+    credential: &impl CredentialT<Properties = T>,
     timestamp: Timestamp,
   ) -> ValidationUnitResult {
     if credential.valid_from() <= timestamp {
@@ -92,7 +99,7 @@ impl JwtCredentialValidatorUtils {
   /// Validate that the relationship between the `holder` and the credential subjects is in accordance with
   /// `relationship`.
   pub fn check_subject_holder_relationship<T>(
-    credential: &dyn CredentialT<Properties = T>,
+    credential: &impl CredentialT<Properties = T>,
     holder: &Url,
     relationship: SubjectHolderRelationship,
   ) -> ValidationUnitResult {
@@ -121,13 +128,17 @@ impl JwtCredentialValidatorUtils {
   ///
   /// Only supports `StatusList2021`.
   #[cfg(feature = "status-list-2021")]
-  pub fn check_status_with_status_list_2021<T>(
-    credential: &dyn CredentialT<Properties = T>,
+  pub fn check_status_with_status_list_2021<T, C>(
+    credential: &C,
     status_list_credential: &StatusList2021Credential,
     status_check: crate::validator::StatusCheck,
-  ) -> ValidationUnitResult {
+  ) -> ValidationUnitResult
+  where
+    C: CredentialT<Properties = Object>,
+    C::Status: Clone,
+    StatusList2021Entry: TryFrom<C::Status, Error: std::fmt::Display>,
+  {
     use crate::revocation::status_list_2021::CredentialStatus;
-    use crate::revocation::status_list_2021::StatusList2021Entry;
 
     if status_check == crate::validator::StatusCheck::SkipAll {
       return Ok(());
@@ -137,7 +148,7 @@ impl JwtCredentialValidatorUtils {
       return Ok(());
     };
 
-    let status = StatusList2021Entry::try_from(status)
+    let status = StatusList2021Entry::try_from(status.clone())
       .map_err(|e| JwtValidationError::InvalidStatus(crate::Error::InvalidStatus(e.to_string())))?;
     if Some(status.status_list_credential()) == status_list_credential.id.as_ref()
       && status.purpose() == status_list_credential.purpose()
@@ -161,11 +172,16 @@ impl JwtCredentialValidatorUtils {
   ///
   /// Only supports `RevocationBitmap2022`.
   #[cfg(feature = "revocation-bitmap")]
-  pub fn check_status<DOC: AsRef<identity_document::document::CoreDocument>, T>(
-    credential: &dyn CredentialT<Properties = T>,
+  pub fn check_status<DOC, T, C>(
+    credential: &C,
     trusted_issuers: &[DOC],
     status_check: crate::validator::StatusCheck,
-  ) -> ValidationUnitResult {
+  ) -> ValidationUnitResult
+  where
+    DOC: AsRef<identity_document::document::CoreDocument>,
+    C: CredentialT<Properties = T>,
+    C::Status: Clone + Into<StatusV2>,
+  {
     use identity_did::CoreDID;
     use identity_document::document::CoreDocument;
 
@@ -178,17 +194,21 @@ impl JwtCredentialValidatorUtils {
     };
 
     // Check status is supported.
-    if status.type_ != crate::revocation::RevocationBitmap::TYPE {
+    if !status
+      .type_()
+      .iter()
+      .any(|ty| ty.as_str() == crate::revocation::RevocationBitmap::TYPE)
+    {
       if status_check == crate::validator::StatusCheck::SkipUnsupported {
         return Ok(());
       }
       return Err(JwtValidationError::InvalidStatus(crate::Error::InvalidStatus(format!(
         "unsupported type '{}'",
-        status.type_
+        status.type_().first().expect("statuses always have at least one type")
       ))));
     }
-    let status: crate::credential::RevocationBitmapStatus =
-      crate::credential::RevocationBitmapStatus::try_from(status.clone()).map_err(JwtValidationError::InvalidStatus)?;
+    let status: RevocationBitmapStatus = RevocationBitmapStatus::try_from(status.clone().into())
+      .map_err(|e: crate::Error| JwtValidationError::InvalidStatus(crate::Error::InvalidStatus(e.to_string())))?;
 
     // Check the credential index against the issuer's DID Document.
     let issuer_did: CoreDID = Self::extract_issuer(credential)?;
@@ -229,7 +249,7 @@ impl JwtCredentialValidatorUtils {
   ///
   /// Fails if the issuer field is not a valid DID.
   pub fn extract_issuer<D, T>(
-    credential: &dyn CredentialT<Properties = T>,
+    credential: &impl CredentialT<Properties = T>,
   ) -> std::result::Result<D, JwtValidationError>
   where
     D: DID,

--- a/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator_utils.rs
+++ b/identity_credential/src/validator/jwt_credential_validation/jwt_credential_validator_utils.rs
@@ -134,7 +134,7 @@ impl JwtCredentialValidatorUtils {
     status_check: crate::validator::StatusCheck,
   ) -> ValidationUnitResult
   where
-    C: CredentialT<Properties = Object>,
+    C: CredentialT<Properties = T>,
     C::Status: Clone,
     StatusList2021Entry: TryFrom<C::Status, Error: std::fmt::Display>,
   {

--- a/identity_iota/Cargo.toml
+++ b/identity_iota/Cargo.toml
@@ -58,6 +58,8 @@ revocation-bitmap = [
 
 # Enables revocation with `StatusList2021`.
 status-list-2021 = ["revocation-bitmap", "identity_credential/status-list-2021"]
+# Enables revocation with `BitstringStatusListV1`.
+bitstring-status-list = ["revocation-bitmap", "identity_credential/bitstring-status-list"]
 
 # Enables support for the `Resolver`.
 resolver = ["dep:identity_resolver"]

--- a/identity_iota_core/packages/iota_identity/Move.lock
+++ b/identity_iota_core/packages/iota_identity/Move.lock
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.18.0-beta"
+compiler-version = "1.22.1"
 edition = "2024"
 flavor = "iota"
 
@@ -61,9 +61,9 @@ latest-published-id = "0x8896ab04fe24c044c54925df3f8a7c383a8d1d6f6bbb95d1c57cfa9
 published-version = "1"
 
 [env.localnet]
-chain-id = "a6bad7ce"
-original-published-id = "0x057742ffe67851bc2f0d31affcd23925cfc78633bb2c11ae53cacfafb0236f96"
-latest-published-id = "0x057742ffe67851bc2f0d31affcd23925cfc78633bb2c11ae53cacfafb0236f96"
+chain-id = "cac5a611"
+original-published-id = "0xe772e1e2fc5de5020697318b17333d25f3b1d37785b202a9397eee2327d32163"
+latest-published-id = "0xe772e1e2fc5de5020697318b17333d25f3b1d37785b202a9397eee2327d32163"
 published-version = "1"
 
 [env.mainnet]


### PR DESCRIPTION
# Description of change
Implement [BitstringStatusList v1](https://www.w3.org/TR/vc-bitstring-status-list/) and fix an issue with `CredentialV2`'s status.

## Links to any relevant issues
Closes #1839 